### PR TITLE
Create a store for "connected and logged in"

### DIFF
--- a/src/lib/components/Connect.svelte
+++ b/src/lib/components/Connect.svelte
@@ -3,28 +3,28 @@
 	import { walletStore } from '$lib/stores/wallet/wallet';
 	import Button from '$components/Button.svelte';
 	import { authStore } from '$lib/stores/auth/auth';
+	import connectedAndLoggedIn from '$lib/stores/connectedAndLoggedIn';
 
 	$: label = $walletStore.connected && formatAddress($walletStore.address);
 
-	$: connectedAndLoggedIn =
-		$walletStore.connected &&
-		$authStore.authenticated &&
-		$walletStore.address === $authStore.address;
-
 	let locked: boolean;
+
+	$: {
+		console.log($connectedAndLoggedIn);
+	}
 
 	async function logIn() {
 		locked = true;
 		try {
 			if (!$walletStore.connected) await walletStore.connect();
-			if (!connectedAndLoggedIn) await authStore.authenticate($walletStore);
+			if (!$connectedAndLoggedIn) await authStore.authenticate($walletStore);
 		} finally {
 			locked = false;
 		}
 	}
 </script>
 
-{#if connectedAndLoggedIn}
+{#if $connectedAndLoggedIn}
 	<Button variant="outline" on:click={() => walletStore.disconnect()}>{label}</Button>
 {:else if locked}
 	<Button disabled variant="outline">. . .</Button>

--- a/src/lib/stores/connectedAndLoggedIn.ts
+++ b/src/lib/stores/connectedAndLoggedIn.ts
@@ -1,0 +1,13 @@
+import { derived } from 'svelte/store';
+import { authStore } from './auth/auth';
+import { walletStore } from './wallet/wallet';
+
+const connectedAndLoggedIn = derived(
+	[walletStore, authStore],
+	([$walletStore, $authStore]) =>
+		$walletStore.connected &&
+		$authStore.authenticated &&
+		$walletStore.address === $authStore.address
+);
+
+export default connectedAndLoggedIn;

--- a/src/routes/dashboard/index.svelte
+++ b/src/routes/dashboard/index.svelte
@@ -11,13 +11,9 @@
 	import { authStore } from '$lib/stores/auth/auth';
 	import { browser } from '$app/env';
 	import EmptyState from '$lib/components/EmptyState.svelte';
+	import connectedAndLoggedIn from '$lib/stores/connectedAndLoggedIn';
 
 	let workstreams: Workstream[] = [];
-
-	$: connectedAndLoggedIn =
-		$walletStore.connected &&
-		$authStore.authenticated &&
-		$walletStore.address === $authStore.address;
 
 	let locked: boolean;
 
@@ -55,7 +51,7 @@
 		locked = true;
 		try {
 			if (!$walletStore.connected) await walletStore.connect();
-			if (!connectedAndLoggedIn) await authStore.authenticate($walletStore);
+			if (!$connectedAndLoggedIn) await authStore.authenticate($walletStore);
 		} finally {
 			locked = false;
 		}


### PR DESCRIPTION
We were starting to duplicate a check for the user being both connected to Metamask & authenticated with the API in multiple places, so this PR adds a derived store value that we can use instead.