### PR TITLE
Don't allow applying for already applied-to workstreams

### DIFF
--- a/src/lib/components/ExploreCard.svelte
+++ b/src/lib/components/ExploreCard.svelte
@@ -11,6 +11,7 @@
 	import Rate from '$components/Rate.svelte';
 	import Timeframe from '$components/Timeframe.svelte';
 	import ApplyModal from '$components/ApplyModal.svelte';
+	import { walletStore } from '$lib/stores/wallet/wallet';
 
 	export let workstream: Workstream;
 
@@ -31,6 +32,7 @@
 		<Button
 			variant="outline"
 			icon={Apply}
+			disabled={$walletStore.connected && workstream.applicants?.includes($walletStore.address)}
 			on:click={() => modal.show(ApplyModal, undefined, { workstream })}
 		>
 			Apply

--- a/src/lib/components/WorkstreamDetail.svelte
+++ b/src/lib/components/WorkstreamDetail.svelte
@@ -9,6 +9,7 @@
 	import Button from '$components/Button.svelte';
 	import Markdown from '$components/Markdown.svelte';
 	import type { Workstream } from '$lib/stores/workstreams/types';
+	import { walletStore } from '$lib/stores/wallet/wallet';
 
 	export let workstream: Workstream;
 </script>
@@ -36,7 +37,11 @@
 					<p class="timeframe">{timeframeFormat(workstream.duration)}</p>
 				</div>
 			{/if}
-			<Button icon={Apply} on:click={() => modal.show(ApplyModal, undefined, { workstream })}>
+			<Button
+				disabled={$walletStore.connected && workstream.applicants?.includes($walletStore.address)}
+				icon={Apply}
+				on:click={() => modal.show(ApplyModal, undefined, { workstream })}
+			>
 				Apply
 			</Button>
 		</div>

--- a/src/lib/stores/wallet/wallet.ts
+++ b/src/lib/stores/wallet/wallet.ts
@@ -23,7 +23,7 @@ function updateAccounts(walletData: WalletData, accounts: string[]): WalletData 
 		return {
 			connected: true,
 			connecting: (walletData.connected && walletData.connecting) || false,
-			address: accounts[0],
+			address: accounts[0].toLowerCase(),
 			provider,
 			signer: provider.getSigner()
 		};
@@ -76,7 +76,7 @@ export const walletStore = (() => {
 		set({
 			connected: true,
 			connecting: false,
-			address: accounts[0],
+			address: accounts[0].toLowerCase(),
 			provider,
 			signer: provider.getSigner()
 		});

--- a/src/lib/stores/workstreams/types.ts
+++ b/src/lib/stores/workstreams/types.ts
@@ -27,6 +27,7 @@ export interface WorkstreamBase {
 	payment: Payment;
 	title: string;
 	desc: string;
+	applicants?: string[];
 }
 
 export interface Payment {


### PR DESCRIPTION
Checks the newly-added `applicants` array on workstreams to decide if the user may apply to a given workstream.