### PR TITLE
fix: Logout on auth clear & prevent applying to something while logged out

### DIFF
--- a/src/lib/components/ExploreCard.svelte
+++ b/src/lib/components/ExploreCard.svelte
@@ -12,6 +12,7 @@
   import Timeframe from '$components/Timeframe.svelte';
   import ApplyModal from '$components/ApplyModal.svelte';
   import { walletStore } from '$lib/stores/wallet/wallet';
+  import connectedAndLoggedIn from '$lib/stores/connectedAndLoggedIn';
 
   export let workstream: Workstream;
 
@@ -39,8 +40,11 @@
     <Button
       variant="outline"
       icon={Apply}
-      disabled={$walletStore.connected &&
-        workstream.applicants?.includes($walletStore.address)}
+      disabled={!(
+        $connectedAndLoggedIn &&
+        $walletStore.connected &&
+        !workstream.applicants?.includes($walletStore.address)
+      )}
       on:click={() => modal.show(ApplyModal, undefined, { workstream })}
     >
       Apply

--- a/src/lib/stores/auth/auth.ts
+++ b/src/lib/stores/auth/auth.ts
@@ -104,6 +104,10 @@ export const authStore = (() => {
   }
 
   async function clear() {
+    await fetch(`${BACKEND_URL_BASE}/logout`, {
+      credentials: 'include'
+    });
+
     set({
       expiresAt: null,
       authenticated: false,


### PR DESCRIPTION
Calls the new /logout endpoint on the API to explicitly destroy the client's current session when clicking on "Log out", and also changes the condition for the "Apply" button to be enabled to ensure that you can't apply while logged out.