### PR TITLE
feat: Allow using prod config with a new .env var

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,7 +13,8 @@ const configMap = {
 };
 
 function getConfig(): Config {
-  return process.env.NODE_ENV === 'production'
+  return process.env.NODE_ENV === 'production' ||
+    import.meta.env.VITE_USE_PROD_CONFIG === 'true'
     ? configMap.production
     : configMap.development;
 }


### PR DESCRIPTION
In order to force the prod config (and with that the API URL) to be used during development, create a `.env` file in the project's root directory with the following content: 

```
VITE_USE_PROD_CONFIG=true
```
