### PR TITLE
feat: Ens Name store, resolve avatars

### DIFF
--- a/src/lib/components/User.svelte
+++ b/src/lib/components/User.svelte
@@ -51,6 +51,10 @@
           {toDisplay}
         </p>
       {/key}
+      <!--
+        Placeholder without absolute position to ensure that the component
+        has the right width.
+      -->
       <p class="placeholder typo-text-bold">
         {toDisplay}
       </p>

--- a/src/lib/stores/ensNames.ts
+++ b/src/lib/stores/ensNames.ts
@@ -1,0 +1,43 @@
+import { ethers } from 'ethers';
+import { get, writable } from 'svelte/store';
+
+const ethersProvider = ethers.getDefaultProvider();
+
+export default (() => {
+  const store = writable<{
+    [address: string]: { name?: string; pic?: string };
+  }>({});
+
+  async function lookup(address: string) {
+    const saved = get(store)[address];
+
+    if (!saved) {
+      /*
+        Write an empty object initially in order to prevent
+        multiple in-flight requests for the same address.
+      */
+      store.update((v) => ({ ...v, [address]: {} }));
+
+      const name = await ethersProvider.lookupAddress(address);
+
+      /*
+        Updating with only the name already since the avatar
+        tends to be slow.
+      */
+      store.update((v) => ({ ...v, [address]: { name } }));
+
+      let pic: string;
+
+      if (name) {
+        pic = (await (await ethersProvider.getResolver(name)).getAvatar())?.url;
+      }
+
+      store.update((v) => ({ ...v, [address]: { name, pic } }));
+    }
+  }
+
+  return {
+    subscribe: store.subscribe,
+    lookup
+  };
+})();


### PR DESCRIPTION
- Adds a new `ensNames` store which ensures we only resolve each address once per session.
- Resolves avatar URLs (if present) and displays the avatar in place of the blockie.
- Adds a neat little crossfade transition when a name or avatar is resolved, which makes things look a lot less glitchy.

Resolves #33
Resolves #55 