### PR TITLE
fix: Avatar spacing if address not shown

### DIFF
--- a/src/lib/components/User.svelte
+++ b/src/lib/components/User.svelte
@@ -44,6 +44,7 @@
           alt="user-avatar"
         />
       {/key}
+      <div class="avatar-placeholder" />
     {/if}
     {#if showAddress}
       {#key ensName}
@@ -55,7 +56,7 @@
         Placeholder without absolute position to ensure that the component
         has the right width.
       -->
-      <p class="placeholder typo-text-bold">
+      <p class="address-placeholder typo-text-bold">
         {toDisplay}
       </p>
     {/if}
@@ -65,6 +66,8 @@
 <style>
   .container {
     height: 1.5rem;
+    display: flex;
+    gap: 0.5rem;
     position: relative;
     grid-template-columns: 1.5rem auto;
   }
@@ -73,9 +76,16 @@
     height: 1.5rem;
     border-radius: 0.75rem;
     user-select: none;
+    top: 0;
     left: 0;
     position: absolute;
     background-color: var(--color-foreground-level-5);
+  }
+
+  .avatar-placeholder {
+    width: 1.5rem;
+    height: 1.5rem;
+    opacity: 0;
   }
   .address {
     position: absolute;
@@ -83,8 +93,7 @@
     white-space: nowrap;
   }
 
-  .placeholder {
-    margin-left: 2rem;
+  .address-placeholder {
     opacity: 0;
     white-space: nowrap;
     width: fit-content;


### PR DESCRIPTION
Tiny fix

Before: 
<img width="245" alt="Screenshot 2022-05-02 at 16 59 37" src="https://user-images.githubusercontent.com/1018218/166256654-b16ddfe0-bce1-40f1-bf63-83d157cd570f.png">
 
After:
<img width="160" alt="Screenshot 2022-05-02 at 17 00 12" src="https://user-images.githubusercontent.com/1018218/166256745-28738b81-2e99-4fd5-9956-dba7498cdec7.png">
 