### PR TITLE
feat: Support Testnet ENS, refactor: Improve wallet store

### DIFF
--- a/src/lib/components/ApplicationModal.svelte
+++ b/src/lib/components/ApplicationModal.svelte
@@ -119,7 +119,7 @@
       </Card>
     </div>
 
-    {#if $walletStore.connected && $walletStore.address === workstream.creator}
+    {#if $walletStore.accounts[0] === workstream.creator}
       <div class="actions">
         <Button
           disabled={actionsDisabled}

--- a/src/lib/components/Connect.svelte
+++ b/src/lib/components/Connect.svelte
@@ -18,6 +18,11 @@
     }
   }
 
+  async function logOut() {
+    walletStore.disconnect();
+    authStore.clear();
+  }
+
   let hover = false;
 </script>
 
@@ -25,7 +30,7 @@
   {#if $connectedAndLoggedIn}
     {#if hover}
       <div
-        on:click={() => walletStore.disconnect()}
+        on:click={logOut}
         transition:fade={{ duration: 100 }}
         class="log-out-overlay"
       >
@@ -39,6 +44,10 @@
     </div>
   {:else if locked}
     <Button disabled variant="outline">. . .</Button>
+  {:else if !$walletStore.initialized}
+    <Button disabled variant="outline">Initializing...</Button>
+  {:else if $walletStore.walletPresent === false}
+    <Button disabled variant="outline">Install MetaMask to log in</Button>
   {:else}
     <Button on:click={() => logIn()} variant="outline"
       >Sign in with Ethereum</Button

--- a/src/lib/components/User.svelte
+++ b/src/lib/components/User.svelte
@@ -7,6 +7,7 @@
   import { onMount } from 'svelte';
   import { formatAddress } from '$lib/utils/format';
   import ensNames from '$lib/stores/ensNames';
+  import { walletStore } from '$lib/stores/wallet/wallet';
 
   export let showAvatar = true;
   export let showAddress = true;
@@ -21,8 +22,18 @@
   onMount(() => {
     uriData = blockyDataUri(address);
 
-    ensNames.lookup(address);
+    lookup();
   });
+
+  function lookup() {
+    ensNames.lookup(address, $walletStore.connected && $walletStore.provider);
+  }
+
+  // Reload ens names if network changes.
+  $: {
+    $walletStore.connected && $walletStore.chainId;
+    lookup();
+  }
 
   const blockyDataUri = (urn: string) => {
     return createIcon({

--- a/src/lib/components/User.svelte
+++ b/src/lib/components/User.svelte
@@ -26,12 +26,12 @@
   });
 
   function lookup() {
-    ensNames.lookup(address, $walletStore.connected && $walletStore.provider);
+    ensNames.lookup(address, $walletStore.provider);
   }
 
   // Reload ens names if network changes.
   $: {
-    $walletStore.connected && $walletStore.chainId;
+    $walletStore.chainId;
     lookup();
   }
 

--- a/src/lib/components/User.svelte
+++ b/src/lib/components/User.svelte
@@ -29,12 +29,6 @@
     ensNames.lookup(address, $walletStore.provider);
   }
 
-  // Reload ens names if network changes.
-  $: {
-    $walletStore.chainId;
-    lookup();
-  }
-
   const blockyDataUri = (urn: string) => {
     return createIcon({
       seed: urn.toLowerCase(),

--- a/src/lib/components/WorkstreamDetail.svelte
+++ b/src/lib/components/WorkstreamDetail.svelte
@@ -32,12 +32,9 @@
 
   let applied: boolean =
     $connectedAndLoggedIn &&
-    $walletStore.connected &&
-    workstream.applicants?.includes($walletStore.address);
+    workstream.applicants?.includes($walletStore.accounts[0]);
   let creator: boolean =
-    $connectedAndLoggedIn &&
-    $walletStore.connected &&
-    workstream.creator === $walletStore.address;
+    $connectedAndLoggedIn && workstream.creator === $walletStore.accounts[0];
 
   $: {
     if (workstream.state === WorkstreamState.ACTIVE) {
@@ -117,7 +114,7 @@
                   {#if application.counterOffer}
                     <p class="proposal">Rejected</p>
                   {/if}
-                  {#if $connectedAndLoggedIn && $walletStore.connected && $walletStore.address === workstream.creator}
+                  {#if $connectedAndLoggedIn && $walletStore.accounts[0] === workstream.creator}
                     <Button variant="primary" icon={ThumbsDown}>Deny</Button>
                   {/if}
                   <Button
@@ -141,7 +138,7 @@
             {#if !creator}
               <Tooltip value={applied ? "You've already applied" : null}>
                 <Button
-                  disabled={applied}
+                  disabled={applied || !$connectedAndLoggedIn}
                   icon={Apply}
                   on:click={() =>
                     modal.show(ApplyModal, undefined, { workstream })}
@@ -178,7 +175,7 @@
                       />
                     </p>
                   {/if}
-                  {#if $connectedAndLoggedIn && $walletStore.connected && $walletStore.address === workstream.creator}
+                  {#if $connectedAndLoggedIn && $walletStore.connected && $walletStore.accounts[0] === workstream.creator}
                     <Button variant="primary" icon={ThumbsDown}>Deny</Button>
                   {/if}
                   <Button

--- a/src/lib/components/WorkstreamPageHeader.svelte
+++ b/src/lib/components/WorkstreamPageHeader.svelte
@@ -15,8 +15,7 @@
   <h4>{workstream.title}</h4>
   <Button
     disabled={$connectedAndLoggedIn &&
-      $walletStore.connected &&
-      workstream.applicants?.includes($walletStore.address)}
+      workstream.applicants?.includes($walletStore.accounts[0])}
     icon={Apply}
     on:click={() => modal.show(ApplyModal, undefined, { workstream })}
     >Apply</Button

--- a/src/lib/stores/auth/auth.ts
+++ b/src/lib/stores/auth/auth.ts
@@ -78,14 +78,14 @@ export const authStore = (() => {
     if (!walletData.connected) throw new Error('Initialize Wallet first');
 
     const message = await createSiweMessage(
-      walletData.address,
+      walletData.accounts[0],
       'Please sign this message to log in to Radicle Workstreams. Since this' +
         ' is not a transaction, there will be no transaction costs.'
     );
 
-    const signature = await walletData.signer.signMessage(
-      message.prepareMessage()
-    );
+    const signature = await walletData.provider
+      .getSigner()
+      .signMessage(message.prepareMessage());
 
     const result = await sendSignatureForVerification(
       message.prepareMessage(),
@@ -96,7 +96,7 @@ export const authStore = (() => {
       set({
         expiresAt: message.expirationTime,
         authenticated: true,
-        address: walletData.address
+        address: walletData.accounts[0]
       });
     }
 

--- a/src/lib/stores/connectedAndLoggedIn.ts
+++ b/src/lib/stores/connectedAndLoggedIn.ts
@@ -5,9 +5,7 @@ import { walletStore } from './wallet/wallet';
 const connectedAndLoggedIn = derived(
   [walletStore, authStore],
   ([$walletStore, $authStore]) =>
-    $walletStore.connected &&
-    $authStore.authenticated &&
-    $walletStore.address === $authStore.address
+    $authStore.authenticated && $walletStore.accounts[0] === $authStore.address
 );
 
 export default connectedAndLoggedIn;

--- a/src/lib/stores/ensNames.ts
+++ b/src/lib/stores/ensNames.ts
@@ -21,8 +21,6 @@ export default (() => {
       */
       store.update((v) => ({ ...v, [address]: {} }));
 
-      console.log(provider?.network);
-
       const name = await (provider || defaultProvider).lookupAddress(address);
 
       /*

--- a/src/lib/stores/ensNames.ts
+++ b/src/lib/stores/ensNames.ts
@@ -1,14 +1,17 @@
 import { ethers } from 'ethers';
 import { get, writable } from 'svelte/store';
 
-const ethersProvider = ethers.getDefaultProvider();
+const defaultProvider = ethers.getDefaultProvider();
 
 export default (() => {
   const store = writable<{
     [address: string]: { name?: string; pic?: string };
   }>({});
 
-  async function lookup(address: string) {
+  async function lookup(
+    address: string,
+    provider?: ethers.providers.BaseProvider
+  ) {
     const saved = get(store)[address];
 
     if (!saved) {
@@ -18,7 +21,9 @@ export default (() => {
       */
       store.update((v) => ({ ...v, [address]: {} }));
 
-      const name = await ethersProvider.lookupAddress(address);
+      console.log(provider?.network);
+
+      const name = await (provider || defaultProvider).lookupAddress(address);
 
       /*
         Updating with only the name already since the avatar
@@ -29,7 +34,11 @@ export default (() => {
       let pic: string;
 
       if (name) {
-        pic = (await (await ethersProvider.getResolver(name)).getAvatar())?.url;
+        pic = (
+          await (
+            await (provider || defaultProvider).getResolver(name)
+          ).getAvatar()
+        )?.url;
       }
 
       store.update((v) => ({ ...v, [address]: { name, pic } }));

--- a/src/lib/stores/ensNames.ts
+++ b/src/lib/stores/ensNames.ts
@@ -12,35 +12,31 @@ export default (() => {
     address: string,
     provider?: ethers.providers.BaseProvider
   ) {
-    const saved = get(store)[address];
+    /*
+      Write an empty object initially in order to prevent
+      multiple in-flight requests for the same address.
+    */
+    store.update((v) => ({ ...v, [address]: {} }));
 
-    if (!saved) {
-      /*
-        Write an empty object initially in order to prevent
-        multiple in-flight requests for the same address.
-      */
-      store.update((v) => ({ ...v, [address]: {} }));
+    const name = await (provider || defaultProvider).lookupAddress(address);
 
-      const name = await (provider || defaultProvider).lookupAddress(address);
+    /*
+      Updating with only the name already since the avatar
+      tends to be slow.
+    */
+    store.update((v) => ({ ...v, [address]: { name } }));
 
-      /*
-        Updating with only the name already since the avatar
-        tends to be slow.
-      */
-      store.update((v) => ({ ...v, [address]: { name } }));
+    let pic: string;
 
-      let pic: string;
-
-      if (name) {
-        pic = (
-          await (
-            await (provider || defaultProvider).getResolver(name)
-          ).getAvatar()
-        )?.url;
-      }
-
-      store.update((v) => ({ ...v, [address]: { name, pic } }));
+    if (name) {
+      pic = (
+        await (
+          await (provider || defaultProvider).getResolver(name)
+        ).getAvatar()
+      )?.url;
     }
+
+    store.update((v) => ({ ...v, [address]: { name, pic } }));
   }
 
   return {

--- a/src/lib/stores/ensNames.ts
+++ b/src/lib/stores/ensNames.ts
@@ -12,31 +12,35 @@ export default (() => {
     address: string,
     provider?: ethers.providers.BaseProvider
   ) {
-    /*
-      Write an empty object initially in order to prevent
-      multiple in-flight requests for the same address.
-    */
-    store.update((v) => ({ ...v, [address]: {} }));
+    const saved = get(store)[address];
 
-    const name = await (provider || defaultProvider).lookupAddress(address);
+    if (!saved) {
+      /*
+        Write an empty object initially in order to prevent
+        multiple in-flight requests for the same address.
+      */
+      store.update((v) => ({ ...v, [address]: {} }));
 
-    /*
-      Updating with only the name already since the avatar
-      tends to be slow.
-    */
-    store.update((v) => ({ ...v, [address]: { name } }));
+      const name = await (provider || defaultProvider).lookupAddress(address);
 
-    let pic: string;
+      /*
+        Updating with only the name already since the avatar
+        tends to be slow.
+      */
+      store.update((v) => ({ ...v, [address]: { name } }));
 
-    if (name) {
-      pic = (
-        await (
-          await (provider || defaultProvider).getResolver(name)
-        ).getAvatar()
-      )?.url;
+      let pic: string;
+
+      if (name) {
+        pic = (
+          await (
+            await (provider || defaultProvider).getResolver(name)
+          ).getAvatar()
+        )?.url;
+      }
+
+      store.update((v) => ({ ...v, [address]: { name, pic } }));
     }
-
-    store.update((v) => ({ ...v, [address]: { name, pic } }));
   }
 
   return {

--- a/src/lib/stores/headerContent.ts
+++ b/src/lib/stores/headerContent.ts
@@ -3,7 +3,7 @@ import type { SvelteComponentDev } from 'svelte/internal';
 import { writable } from 'svelte/store';
 
 interface HeaderContentStore {
-  component?: SvelteComponent | SvelteComponentDev;
+  component?: typeof SvelteComponent | typeof SvelteComponentDev;
   props?: { [key: string]: unknown };
   /*
     If undefined, shows as soon as user scrolled down.

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -11,6 +11,7 @@
   import Header from '$components/Header.svelte';
   import ModalLayout from '$components/ModalLayout.svelte';
   import FlyTransition from '$lib/components/FlyTransition.svelte';
+  import { walletStore } from '$lib/stores/wallet/wallet';
   import { onMount } from 'svelte';
   import '../app.css';
 
@@ -33,6 +34,12 @@
     }
   }
 
+  /*
+    We should wait for the wallet store to be initialized in order to
+    be sure that we know the right chain when mounting components.
+  */
+  $: initialized = $walletStore.initialized;
+
   onMount(() => {
     if (browser) {
       prefersDarkThemes = window.matchMedia(
@@ -49,14 +56,16 @@
 </script>
 
 <ModalLayout />
-<div class="wrapper" class:loading={$navigating}>
-  <Header />
-  <main>
-    <FlyTransition {url}>
-      <slot />
-    </FlyTransition>
-  </main>
-</div>
+{#if initialized}
+  <div class="wrapper" class:loading={$navigating}>
+    <Header />
+    <main>
+      <FlyTransition {url}>
+        <slot />
+      </FlyTransition>
+    </main>
+  </div>
+{/if}
 
 <style>
   .wrapper {

--- a/src/routes/dashboard/index.svelte
+++ b/src/routes/dashboard/index.svelte
@@ -91,28 +91,28 @@
       }),
       [SectionName.CREATED]: buildUrl({
         state: 'rfa',
-        createdBy: $walletStore.address,
+        createdBy: $walletStore.accounts[0],
         hasApplicationsToReview: 'false'
       }),
       [SectionName.PENDING_SETUP]: buildUrl({
         state: WorkstreamState.PENDING,
-        createdBy: $walletStore.address
+        createdBy: $walletStore.accounts[0]
       }),
       [SectionName.WAITING_SETUP]: buildUrl({
         state: WorkstreamState.PENDING,
-        assignedTo: $walletStore.address
+        assignedTo: $walletStore.accounts[0]
       }),
       [SectionName.APPLICATIONS_TO_REVIEW]: buildUrl({
-        createdBy: $walletStore.address,
+        createdBy: $walletStore.accounts[0],
         hasApplicationsToReview: 'true'
       }),
       [SectionName.ACTIVE]: buildUrl({
         state: WorkstreamState.ACTIVE,
-        assignedTo: $walletStore.address
+        assignedTo: $walletStore.accounts[0]
       }),
       [SectionName.ENDED]: buildUrl({
         state: WorkstreamState.CLOSED,
-        assignedTo: $walletStore.address
+        assignedTo: $walletStore.accounts[0]
       })
     };
 


### PR DESCRIPTION
Update`walletStore.chainId` when the network changes. Fetch ENS names from the current network and auto-reloads ENS names when the network is updated. Display a warning if the network !== mainnet. No longer crash the application and instead block the login button if no web3 wallet is present.

Resolves #72
Resolves #59 