### PR TITLE
fix: both pages on screen during navigation

### DIFF
--- a/src/lib/components/User.svelte
+++ b/src/lib/components/User.svelte
@@ -14,7 +14,9 @@
   export let showAddress = true;
   export let address: string;
   export let style: string = undefined;
-  let hover: boolean = false;
+  let hover = false;
+
+  let firstRender = true;
 
   let uriData: string;
   $: ensName = $ensNames[address]?.name;
@@ -39,6 +41,8 @@
     }).toDataURL();
   };
 
+  onMount(() => (firstRender = false));
+
   $: url = `/profile/${address}`;
 </script>
 
@@ -56,7 +60,7 @@
     {#if showAvatar}
       {#key avatarUrl}
         <img
-          transition:fade={{ duration: 200 }}
+          in:fade={{ duration: firstRender ? 0 : 200 }}
           class="avatar"
           src={avatarUrl || uriData}
           alt="user-avatar"
@@ -67,7 +71,7 @@
     {#if showAddress}
       {#key ensName}
         <p
-          transition:fade={{ duration: 200 }}
+          in:fade={{ duration: firstRender ? 0 : 200 }}
           class="address typo-text-bold"
           class:hover
         >


### PR DESCRIPTION
There seems to be an issue (?) with SvelteKit that causes it to wait for all `transition` directives on a page to conclude before destroying the component on navigation, which causes both pages to briefly appear on screen during navigation if the previous page had any `out` transitions on it.

This changes the crossfades on the `User` component to only transition `in` and mitigates the problem.

It potentially resolves #84, though I'm not 100% certain. We should keep an eye on it and reopen if necessary.

Additionally, I added a condition to only crossfade the ens name & avatar if we're not on the first render to avoid pop-in immediately after mounted with an already-populated ENS value for the current address in the store.