### PR TITLE
fix: JSON decode error when workstream request fails or returns 404

### DIFF
--- a/src/lib/stores/workstreams/workstreams.ts
+++ b/src/lib/stores/workstreams/workstreams.ts
@@ -68,7 +68,7 @@ export const workstreamsStore = (() => {
     } else {
       return {
         ok: false,
-        error: await response.json()
+        error: await response.text()
       };
     }
   }
@@ -97,7 +97,7 @@ export const workstreamsStore = (() => {
     } else {
       return {
         ok: false,
-        error: await response.json()
+        error: await response.text()
       };
     }
   }


### PR DESCRIPTION
We were attempting to parse error messages from the API as JSON, even though they're not guaranteed to be JSON, causing an error during fetch. For example, 404 responses just have a body of `Not found`.