### PR TITLE
fix: Prevent Metamask "Connect wallet" dialog from blocking page render on first visit

### DIFF
--- a/src/lib/stores/wallet/wallet.ts
+++ b/src/lib/stores/wallet/wallet.ts
@@ -122,10 +122,9 @@ export const walletStore = (() => {
       ]
     });
 
-    const accounts: string[] = await wd.provider.send(
-      'eth_requestAccounts',
-      []
-    );
+    const accounts: string[] = await window.ethereum.request({
+      method: 'eth_accounts'
+    });
 
     const chainId: string = await window.ethereum.request({
       method: 'eth_chainId'

--- a/src/lib/stores/wallet/wallet.ts
+++ b/src/lib/stores/wallet/wallet.ts
@@ -52,7 +52,9 @@ export const walletStore = (() => {
       parsedChainId
     );
 
-    const accounts: string[] = await provider.send('eth_requestAccounts', []);
+    const accounts: string[] = await window.ethereum.request({
+      method: 'eth_accounts'
+    });
 
     if (accounts.length > 0) {
       set({


### PR DESCRIPTION
Previously, the wallet store would wait for a wallet to be connected before initialising, which caused an immediate MetaMask popup when visiting the page. This stops that, while still fetching previously-connected accounts on initialisation. 