### PR TITLE
Simplify design system CSS imports

### DIFF
--- a/scripts/install-design-system-static-assets.sh
+++ b/scripts/install-design-system-static-assets.sh
@@ -10,5 +10,4 @@ set -Eeou pipefail
 
 echo "Installing Radicle Design System assets"
 
-cp ./node_modules/radicle-design-system/static/*.css ./static/styles
 cp ./node_modules/radicle-design-system/static/fonts/*.otf ./static/fonts

--- a/src/app.css
+++ b/src/app.css
@@ -1,8 +1,8 @@
-@import '../static/styles/reset.css';
-@import '../static/styles/global.css';
-@import '../static/styles/colors.css';
-@import '../static/styles/elevation.css';
-@import '../static/styles/typography.css';
+@import 'radicle-design-system/static/reset.css';
+@import 'radicle-design-system/static/global.css';
+@import 'radicle-design-system/static/colors.css';
+@import 'radicle-design-system/static/elevation.css';
+@import 'radicle-design-system/static/typography.css';
 
 /* All design system style overrides go here. */
 html,


### PR DESCRIPTION
Turns out this works just fine.

You can just delete the `./static/styles` folder locally after this is merged.