### PR TITLE
fix: Bottom padding on `main`, align margins of header and content

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -101,8 +101,6 @@
   </div>
 </header>
 
-<div class="spacer" />
-
 <style>
   header {
     top: 0;
@@ -142,10 +140,6 @@
   .buttons {
     display: flex;
     gap: 0.5rem;
-  }
-
-  .spacer {
-    height: 6rem;
   }
 
   nav {

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -63,11 +63,9 @@
 
 <style>
   .wrapper {
-    height: 100vh;
     max-width: 90rem;
-    min-width: 40rem;
     margin: 0 auto;
-    padding: 1.5rem;
+    padding: 6rem 1rem 3rem 1rem;
     transition: opacity 0.3s;
   }
 
@@ -108,6 +106,5 @@
   main {
     display: flex;
     flex-direction: column;
-    margin: 1rem 0 4rem;
   }
 </style>


### PR DESCRIPTION
- Aligns the margins to screen edge to be a consistent `1rem` across header and content.
- Adds a bottom margin to `main` so that the bottom of content doesn't meet the bottom screen edge.