### PR TITLE
feat: History view

### DIFF
--- a/src/lib/components/BalanceButton.svelte
+++ b/src/lib/components/BalanceButton.svelte
@@ -3,11 +3,14 @@
   import Button from 'radicle-design-system/Button.svelte';
   import TopUpIcon from 'radicle-design-system/icons/Topup.svelte';
   import InfoCircle from 'radicle-design-system/icons/InfoCircle.svelte';
+  import RoadIcon from 'radicle-design-system/icons/Road.svelte';
 
   import drips from '$lib/stores/drips';
   import { currencyFormat, padFloatString } from '$lib/utils/format';
   import { workstreamsStore } from '$lib/stores/workstreams';
   import LoadingDots from './LoadingDots.svelte';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
 
   const estimates = workstreamsStore.estimates;
 
@@ -33,6 +36,11 @@
       txInFlight = false;
     }
   }
+
+  function navigate(path: string) {
+    hover = false;
+    goto(path);
+  }
 </script>
 
 <div
@@ -40,7 +48,7 @@
   on:mouseleave={() => (hover = false)}
   on:mouseenter={() => (hover = true)}
 >
-  <Button variant="outline">
+  <Button on:click={() => navigate('/history')} variant="outline">
     <span class="typo-text-mono">
       {#if estimate}
         {padFloatString(estimate)} DAI
@@ -93,6 +101,12 @@
       </div>
       {#if withdrawable}
         <div class="actions">
+          <Button
+            disabled={$page.routeId === 'history'}
+            variant="outline"
+            icon={RoadIcon}
+            on:click={() => navigate('/history')}>View history</Button
+          >
           <Button disabled={collectBlocked} icon={TopUpIcon} on:click={collect}
             >Withdraw {withdrawable} DAI</Button
           >
@@ -112,7 +126,9 @@
   }
 
   .actions {
-    width: fit-content;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
   }
 
   .hover-pad {

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -113,7 +113,7 @@
     height: 4.5rem;
     box-sizing: border-box;
     background-color: var(--color-background);
-    z-index: 10;
+    z-index: 1000;
     position: fixed;
     transition: box-shadow 0.3s, transform 0.3s;
   }

--- a/src/lib/components/History/EarnedInbetweenDropdown.svelte
+++ b/src/lib/components/History/EarnedInbetweenDropdown.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import { fly } from 'svelte/transition';
+
+  import type { EnrichedWorkstream } from '$lib/stores/workstreams';
+  import type { Money } from '$lib/stores/workstreams/types';
+  import { currencyFormat } from '$lib/utils/format';
+  import Plus from 'radicle-design-system/icons/Plus.svelte';
+
+  export let amountsEarned: { workstream: EnrichedWorkstream; amount: Money }[];
+  export let window: { from: Date; to: Date };
+
+  let hover = false;
+
+  function formatDate(date: Date) {
+    return Intl.DateTimeFormat('en-US', {
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: 'numeric',
+      second: '2-digit'
+    }).format(date);
+  }
+</script>
+
+<template>
+  <div
+    on:mouseleave={() => (hover = false)}
+    on:mouseenter={() => (hover = true)}
+    class="text"
+  >
+    <slot />
+    {#if hover}
+      <div class="puffer" />
+      <div
+        class="earned-inbetween-dropdown"
+        transition:fly|local={{ y: 10, duration: 300 }}
+      >
+        <div class="amounts">
+          <p class="typo-text-small">
+            Earned between <span class="typo-text-small-bold"
+              >{formatDate(window.from)}</span
+            >
+            and
+            <span class="typo-text-small-bold">{formatDate(window.to)}</span>
+          </p>
+          {#each amountsEarned as amountEarned}
+            <div class="amount-earned">
+              <div class="icon">
+                <Plus style="fill: var(--color-positive)" />
+              </div>
+              <p class="title typo-text-bold">
+                {amountEarned.workstream.data.title}
+              </p>
+              <p class="amount typo-text-mono-bold">
+                +{currencyFormat(amountEarned.amount.wei)} DAI
+              </p>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+  </div>
+</template>
+
+<style scoped>
+  .amount-earned {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .title {
+    color: var(--color-foreground);
+    flex: 1;
+  }
+
+  .amount {
+    color: var(--color-primary);
+    font-size: 14px;
+  }
+
+  .icon {
+    height: 2rem;
+    width: 2rem;
+    border-radius: 1rem;
+    background-color: var(--color-positive-level-1);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .text {
+    display: inline-block;
+    position: relative;
+    color: var(--color-foreground-level-6);
+  }
+
+  .text:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .earned-inbetween-dropdown {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    padding: 1rem;
+    border-radius: 1rem;
+    left: -0.5rem;
+    background-color: var(--color-background);
+    box-shadow: var(--elevation-high);
+    width: 32rem;
+    z-index: 10;
+    cursor: default;
+  }
+
+  .puffer {
+    position: absolute;
+    left: 0;
+    top: 100%;
+    width: 100%;
+    height: 0.25rem;
+  }
+
+  .amounts {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+</style>

--- a/src/lib/components/History/HistoryItem.svelte
+++ b/src/lib/components/History/HistoryItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import TopUpIcon from 'radicle-design-system/icons/Topup.svelte';
+  import CollectIcon from 'radicle-design-system/icons/Topup.svelte';
   import {
     HistoryItemType,
     type HistoryItem
@@ -9,6 +9,7 @@
   import Plus from 'radicle-design-system/icons/Plus.svelte';
   import { currencyFormat } from '$lib/utils/format';
   import EarnedInbetweenDropdown from './EarnedInbetweenDropdown.svelte';
+  import Rate from '../Rate.svelte';
 
   export let historyItem: HistoryItem;
 
@@ -22,23 +23,106 @@
       second: '2-digit'
     }).format(date);
   }
+
+  function isToday(date: Date) {
+    const today = new Date();
+    return (
+      date.getDate() == today.getDate() &&
+      date.getMonth() == today.getMonth() &&
+      date.getFullYear() == today.getFullYear()
+    );
+  }
 </script>
 
 <template>
-  {#if historyItem.type === HistoryItemType.EarnedInbetween && historyItem.meta.earned}
-    <div class="history-inbetween">
+  {#if historyItem.type === HistoryItemType.MonthStartInbetween}
+    <div class="month-start-inbetween">
+      <div class="content">
+        <h3 class="title">
+          {isToday(historyItem.timestamp)
+            ? 'Today'
+            : Intl.DateTimeFormat('en-US', {
+                month: 'long',
+                year: 'numeric'
+              }).format(
+                new Date(
+                  historyItem.timestamp.getFullYear(),
+                  historyItem.timestamp.getMonth() - 1
+                )
+              )}
+        </h3>
+        <p class="amounts typo-text-small">
+          {#if historyItem.meta.earned.streams.length > 0}
+            earned <span class="amount typo-text-mono-bold"
+              >{currencyFormat(historyItem.meta.earned.total.wei)} DAI</span
+            >
+            from <EarnedInbetweenDropdown
+              amountsEarned={historyItem.meta.earned.streams}
+              amountsSpent={[]}
+              timeWindow={historyItem.meta.window}
+              >{historyItem.meta.earned.streams.length} workstream{historyItem
+                .meta.earned.streams.length > 1
+                ? 's'
+                : ''}</EarnedInbetweenDropdown
+            >
+            {#if historyItem.meta.spent.streams.length > 0}and{/if}
+          {/if}
+          {#if historyItem.meta.spent.streams.length > 0}
+            streamed <span class="amount typo-text-mono-bold"
+              >{currencyFormat(historyItem.meta.spent.total.wei)} DAI</span
+            >
+            to <EarnedInbetweenDropdown
+              amountsEarned={[]}
+              amountsSpent={historyItem.meta.spent.streams}
+              timeWindow={historyItem.meta.window}
+              >{historyItem.meta.spent.streams.length} workstream{historyItem
+                .meta.spent.streams.length > 1
+                ? 's'
+                : ''}</EarnedInbetweenDropdown
+            >
+          {/if}
+          this month
+        </p>
+      </div>
+      <div class="line" />
+    </div>
+  {/if}
+  {#if historyItem.type === HistoryItemType.StreamedInbetween}
+    <div class="streamed-inbetween">
       <div class="line" />
       <div class="content">
         <div class="circle" />
-        <p class="typo-text-small">
-          Earned <span class="amount typo-text-mono-bold"
-            >{currencyFormat(historyItem.meta.total.wei)} DAI</span
-          >
-          from <EarnedInbetweenDropdown
-            amountsEarned={historyItem.meta.earned}
-            window={historyItem.meta.window}
-            >{historyItem.meta.earned.length} workstreams</EarnedInbetweenDropdown
-          > in {historyItem.meta.secs} seconds
+        <p class="amounts typo-text-small">
+          {#if historyItem.meta.earned.streams.length > 0}
+            earned <span class="amount typo-text-mono-bold"
+              >{currencyFormat(historyItem.meta.earned.total.wei)} DAI</span
+            >
+            from <EarnedInbetweenDropdown
+              amountsEarned={historyItem.meta.earned.streams}
+              amountsSpent={[]}
+              timeWindow={historyItem.meta.window}
+              >{historyItem.meta.earned.streams.length} workstream{historyItem
+                .meta.earned.streams.length > 1
+                ? 's'
+                : ''}</EarnedInbetweenDropdown
+            >
+            {#if historyItem.meta.spent.streams.length > 0}and{/if}
+          {/if}
+          {#if historyItem.meta.spent.streams.length > 0}
+            streamed <span class="amount typo-text-mono-bold"
+              >{currencyFormat(historyItem.meta.spent.total.wei)} DAI</span
+            >
+            to <EarnedInbetweenDropdown
+              amountsEarned={[]}
+              amountsSpent={historyItem.meta.spent.streams}
+              timeWindow={historyItem.meta.window}
+              >{historyItem.meta.spent.streams.length} workstream{historyItem
+                .meta.spent.streams.length > 1
+                ? 's'
+                : ''}</EarnedInbetweenDropdown
+            >
+          {/if}
+          in {historyItem.meta.secs} seconds
         </p>
       </div>
     </div>
@@ -46,16 +130,37 @@
   {#if historyItem.type === HistoryItemType.StreamStart}
     <div class="history-card">
       <div class="icon primary">
-        <TopUpIcon style="fill: var(--color-primary)" />
+        <Plus style="fill: var(--color-primary)" />
       </div>
       <h4>
-        Stream <a
+        {historyItem.meta.workstream.direction === 'incoming'
+          ? 'Started earning for'
+          : 'Started outgoing stream'}
+        <a
           class="highlight"
           href={`/workstream/${historyItem.meta.workstream.data.id}`}
           >{historyItem.meta.workstream.data.title}</a
-        > set up and started
+        >
       </h4>
-      <p>{formatDate(historyItem.timestamp)}</p>
+      <p class="date">{formatDate(historyItem.timestamp)}</p>
+      <p class="potential amount typo-text-mono-bold">
+        <Rate
+          ratePerSecond={historyItem.meta.workstream.onChainData.amtPerSec}
+          total={historyItem.meta.workstream.data.total}
+        />
+      </p>
+    </div>
+  {/if}
+  {#if historyItem.type === HistoryItemType.Withdrawal}
+    <div class="history-card">
+      <div class="icon primary">
+        <CollectIcon style="fill: var(--color-primary)" />
+      </div>
+      <h4><span class="highlight">Withdrawal</span></h4>
+      <p class="date">{formatDate(historyItem.timestamp)}</p>
+      <p class="amount typo-text-mono-bold">
+        -{currencyFormat(historyItem.meta.amount.wei)} DAI
+      </p>
     </div>
   {/if}
   {#if historyItem.type === HistoryItemType.StreamOutOfFunds}
@@ -64,7 +169,8 @@
         <Cross style="fill: var(--color-foreground-level-5)" />
       </div>
       <h4>
-        Stream <a
+        {historyItem.meta.workstream.direction} stream
+        <a
           class="highlight"
           href={`/workstream/${historyItem.meta.workstream.data.id}`}
           >{historyItem.meta.workstream.data.title}</a
@@ -79,7 +185,8 @@
         <Pause style="fill: var(--color-foreground-level-5)" />
       </div>
       <h4>
-        Stream <a
+        {historyItem.meta.workstream.direction} stream
+        <a
           class="highlight"
           href={`/workstream/${historyItem.meta.workstream.data.id}`}
           >{historyItem.meta.workstream.data.title}</a
@@ -94,11 +201,16 @@
         <Plus style="fill: var(--color-primary)" />
       </div>
       <h4>
-        Stream <a
+        {historyItem.meta.workstream.direction} stream
+        <a
           class="highlight"
           href={`/workstream/${historyItem.meta.workstream.data.id}`}
           >{historyItem.meta.workstream.data.title}</a
-        > topped up
+        >
+        topped up with
+        <span class="typo-text-mono-bold"
+          >{currencyFormat(historyItem.meta.amount.wei)} DAI</span
+        >
       </h4>
       <p>{formatDate(historyItem.timestamp)}</p>
     </div>
@@ -122,7 +234,7 @@
 
 <style scoped>
   .history-card {
-    margin-top: 1rem;
+    margin-bottom: 1rem;
     padding: 1.5rem;
     display: flex;
     gap: 1rem;
@@ -151,12 +263,15 @@
 
   .amount {
     color: var(--color-primary);
-    font-size: 13px;
   }
 
   h4 {
     font-weight: normal;
     color: var(--color-foreground-level-6);
+  }
+
+  h4::first-letter {
+    text-transform: capitalize;
   }
 
   h4 .highlight {
@@ -168,16 +283,28 @@
     text-decoration: underline;
   }
 
-  .history-inbetween {
-    position: relative;
-    margin-bottom: -1rem;
+  .date {
+    flex: 1;
   }
 
-  .history-inbetween .content {
+  .streamed-inbetween {
+    position: relative;
+    margin-top: -1rem;
+  }
+
+  .streamed-inbetween .content {
     margin: 2rem 0rem 2rem 4.5rem;
   }
 
-  .history-inbetween .circle {
+  .amounts:first-letter {
+    text-transform: capitalize;
+  }
+
+  .amounts .amount {
+    font-size: 13px;
+  }
+
+  .streamed-inbetween .circle {
     position: absolute;
     left: 2.05rem;
     top: 50%;
@@ -189,11 +316,48 @@
     background-color: var(--color-background);
   }
 
-  .history-inbetween .line {
+  .streamed-inbetween .line {
     position: absolute;
     left: 2.5rem;
     height: 100%;
     width: 0.125rem;
     background-color: var(--color-foreground-level-2);
+  }
+
+  .month-start-inbetween {
+    position: relative;
+    margin-top: -1rem;
+    z-index: 100;
+  }
+
+  .month-start-inbetween .line {
+    position: absolute;
+    top: 0;
+    left: 2.5rem;
+    height: 100%;
+    z-index: -1;
+    width: 0.125rem;
+    background: linear-gradient(
+      180deg,
+      var(--color-foreground-level-2),
+      var(--color-background) 2.5rem,
+      var(--color-background) calc(100% - 0.75rem),
+      var(--color-foreground-level-2)
+    );
+  }
+
+  .month-start-inbetween:first-child .line {
+    background: linear-gradient(
+      180deg,
+      var(--color-background),
+      var(--color-background) calc(100% - 0.75rem),
+      var(--color-foreground-level-2)
+    );
+  }
+
+  .month-start-inbetween .content {
+    margin: 3rem 1.5rem 2rem 1.5rem;
+    display: flex;
+    justify-content: space-between;
   }
 </style>

--- a/src/lib/components/History/HistoryItem.svelte
+++ b/src/lib/components/History/HistoryItem.svelte
@@ -328,6 +328,7 @@
     position: relative;
     margin-top: -1rem;
     z-index: 100;
+    justify-content: center;
   }
 
   .month-start-inbetween .line {

--- a/src/lib/components/History/HistoryItem.svelte
+++ b/src/lib/components/History/HistoryItem.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  import TopUpIcon from 'radicle-design-system/icons/Topup.svelte';
+  import {
+    HistoryItemType,
+    type HistoryItem
+  } from '$lib/../routes/history/types';
+  import Pause from 'radicle-design-system/icons/Pause.svelte';
+  import Cross from 'radicle-design-system/icons/Cross.svelte';
+  import Plus from 'radicle-design-system/icons/Plus.svelte';
+  import { currencyFormat } from '$lib/utils/format';
+  import EarnedInbetweenDropdown from './EarnedInbetweenDropdown.svelte';
+
+  export let historyItem: HistoryItem;
+
+  function formatDate(date: Date) {
+    return Intl.DateTimeFormat('en-US', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: 'numeric',
+      second: '2-digit'
+    }).format(date);
+  }
+</script>
+
+<template>
+  {#if historyItem.type === HistoryItemType.EarnedInbetween && historyItem.meta.earned}
+    <div class="history-inbetween">
+      <div class="line" />
+      <div class="content">
+        <div class="circle" />
+        <p class="typo-text-small">
+          Earned <span class="amount typo-text-mono-bold"
+            >{currencyFormat(historyItem.meta.total.wei)} DAI</span
+          >
+          from <EarnedInbetweenDropdown
+            amountsEarned={historyItem.meta.earned}
+            window={historyItem.meta.window}
+            >{historyItem.meta.earned.length} workstreams</EarnedInbetweenDropdown
+          > in {historyItem.meta.secs} seconds
+        </p>
+      </div>
+    </div>
+  {/if}
+  {#if historyItem.type === HistoryItemType.StreamStart}
+    <div class="history-card">
+      <div class="icon primary">
+        <TopUpIcon style="fill: var(--color-primary)" />
+      </div>
+      <h4>
+        Stream <a
+          class="highlight"
+          href={`/workstream/${historyItem.meta.workstream.data.id}`}
+          >{historyItem.meta.workstream.data.title}</a
+        > set up and started
+      </h4>
+      <p>{formatDate(historyItem.timestamp)}</p>
+    </div>
+  {/if}
+  {#if historyItem.type === HistoryItemType.StreamOutOfFunds}
+    <div class="history-card">
+      <div class="icon">
+        <Cross style="fill: var(--color-foreground-level-5)" />
+      </div>
+      <h4>
+        Stream <a
+          class="highlight"
+          href={`/workstream/${historyItem.meta.workstream.data.id}`}
+          >{historyItem.meta.workstream.data.title}</a
+        > ran out of funds
+      </h4>
+      <p>{formatDate(historyItem.timestamp)}</p>
+    </div>
+  {/if}
+  {#if historyItem.type === HistoryItemType.StreamPaused}
+    <div class="history-card">
+      <div class="icon">
+        <Pause style="fill: var(--color-foreground-level-5)" />
+      </div>
+      <h4>
+        Stream <a
+          class="highlight"
+          href={`/workstream/${historyItem.meta.workstream.data.id}`}
+          >{historyItem.meta.workstream.data.title}</a
+        > paused
+      </h4>
+      <p>{formatDate(historyItem.timestamp)}</p>
+    </div>
+  {/if}
+  {#if historyItem.type === HistoryItemType.StreamToppedUp}
+    <div class="history-card">
+      <div class="icon primary">
+        <Plus style="fill: var(--color-primary)" />
+      </div>
+      <h4>
+        Stream <a
+          class="highlight"
+          href={`/workstream/${historyItem.meta.workstream.data.id}`}
+          >{historyItem.meta.workstream.data.title}</a
+        > topped up
+      </h4>
+      <p>{formatDate(historyItem.timestamp)}</p>
+    </div>
+  {/if}
+  {#if historyItem.type === HistoryItemType.StreamUnpaused}
+    <div class="history-card">
+      <div class="icon primary">
+        <Plus style="fill: var(--color-primary)" />
+      </div>
+      <h4>
+        Stream <a
+          class="highlight"
+          href={`/workstream/${historyItem.meta.workstream.data.id}`}
+          >{historyItem.meta.workstream.data.title}</a
+        > unpaused
+      </h4>
+      <p>{formatDate(historyItem.timestamp)}</p>
+    </div>
+  {/if}
+</template>
+
+<style scoped>
+  .history-card {
+    margin-top: 1rem;
+    padding: 1.5rem;
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    outline: 1px solid var(--color-foreground-level-2);
+    border-radius: 1rem;
+  }
+
+  .icon {
+    height: 2rem;
+    width: 2rem;
+    border-radius: 1rem;
+    display: flex;
+    background-color: var(--color-foreground-level-2);
+    justify-content: center;
+    align-items: center;
+  }
+
+  .icon.primary {
+    background-color: var(--color-primary-level-1);
+  }
+
+  p {
+    color: var(--color-foreground-level-5);
+  }
+
+  .amount {
+    color: var(--color-primary);
+    font-size: 13px;
+  }
+
+  h4 {
+    font-weight: normal;
+    color: var(--color-foreground-level-6);
+  }
+
+  h4 .highlight {
+    font-weight: 600;
+    color: var(--color-foreground);
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+  .history-inbetween {
+    position: relative;
+    margin-bottom: -1rem;
+  }
+
+  .history-inbetween .content {
+    margin: 2rem 0rem 2rem 4.5rem;
+  }
+
+  .history-inbetween .circle {
+    position: absolute;
+    left: 2.05rem;
+    top: 50%;
+    transform: translateY(-50%);
+    border-radius: 0.5rem;
+    height: 1rem;
+    width: 1rem;
+    border: 0.125rem solid var(--color-foreground-level-2);
+    background-color: var(--color-background);
+  }
+
+  .history-inbetween .line {
+    position: absolute;
+    left: 2.5rem;
+    height: 100%;
+    width: 0.125rem;
+    background-color: var(--color-foreground-level-2);
+  }
+</style>

--- a/src/lib/components/ModalLayout.svelte
+++ b/src/lib/components/ModalLayout.svelte
@@ -42,7 +42,7 @@
     height: 100%;
     width: 100%;
     position: fixed;
-    z-index: 100;
+    z-index: 10000;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/lib/components/Rate.svelte
+++ b/src/lib/components/Rate.svelte
@@ -17,7 +17,7 @@
     value={currencyFormat(ratePerSecond.wei * BigInt(86400)) +
       ` ${ratePerSecond.currency.toUpperCase()} / 24h`}
   >
-    <p class="typo-text-bold rate">
+    <p class="typo-text-mono-bold rate">
       {#if icon}
         <TokenStreams style="fill: var(--color-primary);" />
       {/if}
@@ -30,8 +30,10 @@
     {#if icon}
       <TokenStreams style="fill: var(--color-primary);" />
     {/if}
-    {currencyFormat(ratePerSecond.wei * BigInt(86400))}
-    {ratePerSecond.currency.toUpperCase()} <span class="typo-text">/ 24h</span>
+    <span class="typo-text-mono-bold">
+      {currencyFormat(ratePerSecond.wei * BigInt(86400))}
+      {ratePerSecond.currency.toUpperCase()}</span
+    > <span class="typo-text-mono">/ 24h</span>
   </p>
 {/if}
 

--- a/src/lib/stores/drips/utils/streamedBetween.ts
+++ b/src/lib/stores/drips/utils/streamedBetween.ts
@@ -1,6 +1,10 @@
 import type { EnrichedWorkstream } from '$lib/stores/workstreams';
 import { Currency, type Money } from '$lib/stores/workstreams/types';
 
+/**
+ * Calculates the exact amounts earned and spent within a given time window and
+ * list of workstreams to consider.
+ */
 export default function streamedBetween(
   timeWindow: { from: Date; to: Date },
   streams: EnrichedWorkstream[]

--- a/src/lib/stores/drips/utils/streamedBetween.ts
+++ b/src/lib/stores/drips/utils/streamedBetween.ts
@@ -1,0 +1,57 @@
+import type { EnrichedWorkstream } from '$lib/stores/workstreams';
+import { Currency, type Money } from '$lib/stores/workstreams/types';
+
+export default function streamedBetween(
+  timeWindow: { from: Date; to: Date },
+  streams: EnrichedWorkstream[]
+) {
+  const amountsStreamed: { workstream: EnrichedWorkstream; amount: Money }[] =
+    [];
+
+  for (const stream of streams) {
+    const events = stream.onChainData.dripsUpdatedEvents;
+
+    let amountStreamed = BigInt(0);
+
+    events.forEach((dew, index) => {
+      const nextDew = events[index + 1];
+      const validSince = dew.fromBlock.timestamp;
+      const validUntil =
+        nextDew?.fromBlock.timestamp || new Date().getTime() / 1000;
+      const amtPerSec =
+        dew.event.args.receivers[0]?.amtPerSec.toBigInt() || BigInt(0);
+
+      if (amtPerSec === BigInt(0)) return;
+
+      const toppedUpUntil =
+        validSince + Number(dew.event.args.balance.toBigInt() / amtPerSec);
+
+      const relevantWindow = {
+        from: Math.max(validSince, timeWindow.from.getTime() / 1000),
+        to: Math.min(timeWindow.to.getTime() / 1000, validUntil, toppedUpUntil)
+      };
+
+      const secondsInWindow = Math.floor(
+        Math.max(relevantWindow.to - relevantWindow.from, 0)
+      );
+      amountStreamed = amountStreamed + BigInt(secondsInWindow) * amtPerSec;
+    });
+
+    if (amountStreamed) {
+      amountsStreamed.push({
+        workstream: stream,
+        amount: {
+          currency: Currency.DAI,
+          wei: amountStreamed
+        }
+      });
+    }
+  }
+
+  return {
+    earned: amountsStreamed.filter(
+      (a) => a.workstream.direction === 'incoming'
+    ),
+    spent: amountsStreamed.filter((a) => a.workstream.direction === 'outgoing')
+  };
+}

--- a/src/lib/stores/workstreams/index.ts
+++ b/src/lib/stores/workstreams/index.ts
@@ -48,6 +48,7 @@ export interface EnrichedWorkstream {
   fetchedAt: Date;
   onChainData?: OnChainData;
   data: Workstream;
+  direction?: 'incoming' | 'outgoing';
 }
 
 export interface DrippingEventWrapper {
@@ -134,11 +135,15 @@ export const workstreamsStore = (() => {
       currentAddress === item.creator ||
       currentAddress === item.acceptedApplication;
 
+    const direction =
+      item.creator === internalState.currentAddress ? 'outgoing' : 'incoming';
+
     // Only enrich workstreams that the user is assigned to or is receiving funds from.
     if (!workstreamAssociatedWithUser || item.state !== WorkstreamState.ACTIVE)
       return {
         data: item,
-        fetchedAt: new Date()
+        fetchedAt: new Date(),
+        direction
       };
 
     const { id, creator, acceptedApplication: assignee, dripsData } = item;
@@ -171,7 +176,8 @@ export const workstreamsStore = (() => {
         dripsUpdatedEvents: dripsUpdatedEvents,
         dripsEntries: dripsAccount.dripsEntries,
         dripsAccount: dripsAccount
-      }
+      },
+      direction
     };
   }
 

--- a/src/routes/history/history.ts
+++ b/src/routes/history/history.ts
@@ -1,5 +1,6 @@
-import type { EnrichedWorkstream } from '$lib/stores/workstreams';
 import { writable } from 'svelte/store';
+
+import type { EnrichedWorkstream } from '$lib/stores/workstreams';
 import type { History, HistoryItem } from './types';
 
 export type HistoryAggregator = (

--- a/src/routes/history/history.ts
+++ b/src/routes/history/history.ts
@@ -34,9 +34,9 @@ function setStreams(newStreams: EnrichedWorkstream[]): typeof history {
 }
 
 /**
- * Add items to a temporary history item queue. Returns self for
- * easy chaining. New items will not appear in the state until `flush`
- * is called.
+ * Add items to a temporary history item queue. Items are automatically
+ * sorted by timestamp. returns self for easy chaining. New items will not
+ * appear in the state until `flush` is called.
  */
 function add(aggregator: HistoryAggregator): typeof history {
   const newState = queue;

--- a/src/routes/history/history.ts
+++ b/src/routes/history/history.ts
@@ -1,0 +1,70 @@
+import type { EnrichedWorkstream } from '$lib/stores/workstreams';
+import { writable } from 'svelte/store';
+import type { History, HistoryItem } from './types';
+
+export type HistoryAggregator = (
+  queue: History,
+  streams: EnrichedWorkstream[]
+) => HistoryItem[];
+
+const state = writable<History>([]);
+
+let queue: History = [];
+let streams: EnrichedWorkstream[] = [];
+
+const historyItemComparator = (a: HistoryItem, b: HistoryItem) => {
+  if (a.timestamp < b.timestamp) {
+    return 1;
+  }
+  if (a.timestamp > b.timestamp) {
+    return -1;
+  }
+  return 0;
+};
+
+/**
+ * Set relevant streams for the history, which will be passed to each
+ * aggregator passed to `add`.
+ */
+function setStreams(newStreams: EnrichedWorkstream[]): typeof history {
+  streams = newStreams;
+
+  return history;
+}
+
+/**
+ * Add items to a temporary history item queue. Returns self for
+ * easy chaining. New items will not appear in the state until `flush`
+ * is called.
+ */
+function add(aggregator: HistoryAggregator): typeof history {
+  const newState = queue;
+
+  newState.push(...aggregator(queue, streams));
+  newState.sort(historyItemComparator);
+
+  queue = newState;
+
+  return history;
+}
+
+/**
+ * Take all items added to the queue via `add`, and update the
+ * history state. Flushes the queue and streams.
+ */
+function flush(): typeof history {
+  state.set(queue);
+  queue = [];
+  streams = [];
+
+  return history;
+}
+
+const history = {
+  subscribe: state.subscribe,
+  add,
+  setStreams,
+  flush
+};
+
+export default history;

--- a/src/routes/history/historyItemAggregators/index.ts
+++ b/src/routes/history/historyItemAggregators/index.ts
@@ -1,0 +1,8 @@
+export { monthStartInbetween } from './monthStartInbetween';
+export { streamedInbetween } from './streamedInbetween';
+export { streamPaused } from './streamPaused';
+export { streamStart } from './streamStart';
+export { streamStartStop } from './streamStartStop';
+export { streamUnpaused } from './streamUnpaused';
+export { today } from './today';
+export { withdrawal } from './withdrawal';

--- a/src/routes/history/historyItemAggregators/monthStartInbetween.ts
+++ b/src/routes/history/historyItemAggregators/monthStartInbetween.ts
@@ -1,0 +1,67 @@
+import streamedBetween from '$lib/stores/drips/utils/streamedBetween';
+import { Currency } from '$lib/stores/workstreams/types';
+import type { HistoryAggregator } from '../history';
+import { HistoryItemType } from '../types';
+
+export const monthStartInbetween: HistoryAggregator = (queue, streams) => {
+  const newItems = [];
+
+  queue.forEach((item, index) => {
+    if (index === 0) return;
+
+    const nextItem = queue[index + 1];
+
+    const { timestamp } = item;
+
+    if (nextItem && nextItem.timestamp.getMonth() < timestamp.getMonth()) {
+      const monthEnd = new Date(timestamp.getFullYear(), timestamp.getMonth());
+      const monthStart = new Date(
+        timestamp.getFullYear(),
+        timestamp.getMonth() - 1
+      );
+
+      const window = {
+        from: monthStart,
+        to: monthEnd
+      };
+
+      const { earned, spent } = streamedBetween(window, streams);
+
+      newItems.push({
+        type: HistoryItemType.MonthStartInbetween,
+        timestamp: monthEnd,
+        meta: {
+          earned: {
+            total: {
+              currency: Currency.DAI,
+              wei: earned.reduce<bigint>(
+                (acc, v) => acc + v.amount.wei,
+                BigInt(0)
+              )
+            },
+            streams: earned
+          },
+          spent: {
+            total: {
+              currency: Currency.DAI,
+              wei: spent.reduce<bigint>(
+                (acc, v) => acc + v.amount.wei,
+                BigInt(0)
+              )
+            },
+            streams: spent
+          },
+          secs: Math.floor(
+            window.to.getTime() / 1000 - window.from.getTime() / 1000
+          ),
+          window: {
+            from: window.from,
+            to: window.to
+          }
+        }
+      });
+    }
+  });
+
+  return newItems;
+};

--- a/src/routes/history/historyItemAggregators/monthStartInbetween.ts
+++ b/src/routes/history/historyItemAggregators/monthStartInbetween.ts
@@ -13,7 +13,7 @@ export const monthStartInbetween: HistoryAggregator = (queue, streams) => {
 
     const { timestamp } = item;
 
-    if (nextItem && nextItem.timestamp.getMonth() < timestamp.getMonth()) {
+    if (nextItem && nextItem.timestamp.getMonth() !== timestamp.getMonth()) {
       const monthEnd = new Date(timestamp.getFullYear(), timestamp.getMonth());
       const monthStart = new Date(
         timestamp.getFullYear(),

--- a/src/routes/history/historyItemAggregators/monthStartInbetween.ts
+++ b/src/routes/history/historyItemAggregators/monthStartInbetween.ts
@@ -3,6 +3,10 @@ import { Currency } from '$lib/stores/workstreams/types';
 import type { HistoryAggregator } from '../history';
 import { HistoryItemType } from '../types';
 
+/*
+  If a new month started inbetween two history items, insert a "month start
+  inbetween", which sums up the amounts earned and spent in the completed month.
+*/
 export const monthStartInbetween: HistoryAggregator = (queue, streams) => {
   const newItems = [];
 

--- a/src/routes/history/historyItemAggregators/streamPaused.ts
+++ b/src/routes/history/historyItemAggregators/streamPaused.ts
@@ -1,11 +1,14 @@
 import type { HistoryAggregator } from '../history';
 import { HistoryItemType, type StreamPaused } from '../types';
 
+/*
+  Get all drips updates that remove the drip to the recipient and create
+  a StreamPaused history item for each.
+*/
 export const streamPaused: HistoryAggregator = (_, streams) =>
   streams.reduce<StreamPaused[]>((acc, ws) => {
     const events = ws.onChainData.dripsUpdatedEvents;
 
-    // Get all updates that remove the drip to the recipient
     const pauses = events.filter(
       (dew) =>
         !dew.event.args.receivers.find(

--- a/src/routes/history/historyItemAggregators/streamPaused.ts
+++ b/src/routes/history/historyItemAggregators/streamPaused.ts
@@ -1,0 +1,29 @@
+import type { HistoryAggregator } from '../history';
+import { HistoryItemType, type StreamPaused } from '../types';
+
+export const streamPaused: HistoryAggregator = (_, streams) =>
+  streams.reduce<StreamPaused[]>((acc, ws) => {
+    const events = ws.onChainData.dripsUpdatedEvents;
+
+    // Get all updates that remove the drip to the recipient
+    const pauses = events.filter(
+      (dew) =>
+        !dew.event.args.receivers.find(
+          (r) => r.receiver.toLowerCase() === ws.data.acceptedApplication
+        )
+    );
+
+    return [
+      ...acc,
+      ...pauses.map(
+        (dew) =>
+          ({
+            type: HistoryItemType.StreamPaused,
+            timestamp: new Date(dew.fromBlock.timestamp * 1000),
+            meta: {
+              workstream: ws
+            }
+          } as StreamPaused)
+      )
+    ];
+  }, []);

--- a/src/routes/history/historyItemAggregators/streamStart.ts
+++ b/src/routes/history/historyItemAggregators/streamStart.ts
@@ -1,0 +1,18 @@
+import type { HistoryAggregator } from '../history';
+import { HistoryItemType } from '../types';
+
+export const streamStart: HistoryAggregator = (_, streams) =>
+  Object.values(streams).map((ws) => {
+    const timestamp = new Date(
+      ws.onChainData.dripsUpdatedEvents[0].fromBlock.timestamp * 1000
+    );
+
+    return {
+      type: HistoryItemType.StreamStart,
+      timestamp,
+      meta: {
+        workstream: ws,
+        byAddress: ws.data.creator
+      }
+    };
+  });

--- a/src/routes/history/historyItemAggregators/streamStart.ts
+++ b/src/routes/history/historyItemAggregators/streamStart.ts
@@ -1,6 +1,10 @@
 import type { HistoryAggregator } from '../history';
 import { HistoryItemType } from '../types';
 
+/* 
+  Find the first drips updated event for each workstream and create
+  a StreamStart history item.
+*/
 export const streamStart: HistoryAggregator = (_, streams) =>
   Object.values(streams).map((ws) => {
     const timestamp = new Date(

--- a/src/routes/history/historyItemAggregators/streamStartStop.ts
+++ b/src/routes/history/historyItemAggregators/streamStartStop.ts
@@ -1,0 +1,85 @@
+import { Currency } from '$lib/stores/workstreams/types';
+import type { HistoryAggregator } from '../history';
+import {
+  HistoryItemType,
+  type StreamOutOfFunds,
+  type StreamToppedUp
+} from '../types';
+
+export const streamStartStop: HistoryAggregator = (_, streams) => {
+  const aggregation = Object.values(streams).reduce<{
+    outOfFunds: StreamOutOfFunds[];
+    toppedUp: StreamToppedUp[];
+  }>(
+    (acc, ws) => {
+      const events = ws.onChainData.dripsUpdatedEvents;
+
+      let newOutOfFundsItems: StreamOutOfFunds[] = [];
+      let newToppedUpItems: StreamToppedUp[] = [];
+
+      events.forEach((wrapper, index) => {
+        const { event, fromBlock } = wrapper;
+        const { receivers, balance } = event.args;
+
+        const amtPerSec = receivers.reduce<bigint>(
+          (acc, r) => acc + r.amtPerSec.toBigInt(),
+          BigInt(0)
+        );
+
+        if (!amtPerSec) {
+          return acc;
+        }
+
+        const nextEvent = events[index + 1];
+        const streamingUntil =
+          fromBlock.timestamp + Number(balance.toBigInt() / amtPerSec);
+        const nextTimestamp =
+          nextEvent?.fromBlock.timestamp || new Date().getTime() / 1000;
+
+        if (streamingUntil > nextTimestamp) {
+          return acc;
+        }
+
+        newOutOfFundsItems = [
+          ...newOutOfFundsItems,
+          {
+            type: HistoryItemType.StreamOutOfFunds,
+            timestamp: new Date(streamingUntil * 1000),
+            meta: {
+              workstream: ws
+            }
+          }
+        ];
+
+        const wasToppedUpAfter =
+          nextEvent && nextEvent.event.args.balance.toBigInt() !== BigInt(0);
+
+        newToppedUpItems = wasToppedUpAfter
+          ? [
+              ...newToppedUpItems,
+              {
+                type: HistoryItemType.StreamToppedUp,
+                timestamp: new Date(nextEvent.fromBlock.timestamp * 1000),
+                meta: {
+                  workstream: ws,
+                  amount: {
+                    currency: Currency.DAI,
+                    wei: nextEvent.event.args.balance.toBigInt()
+                  },
+                  byAddress: ws.data.creator
+                }
+              }
+            ]
+          : newToppedUpItems;
+      });
+
+      return {
+        outOfFunds: [...acc.outOfFunds, ...newOutOfFundsItems],
+        toppedUp: [...acc.toppedUp, ...newToppedUpItems]
+      };
+    },
+    { outOfFunds: [], toppedUp: [] }
+  );
+
+  return [...aggregation.outOfFunds, ...aggregation.toppedUp];
+};

--- a/src/routes/history/historyItemAggregators/streamStartStop.ts
+++ b/src/routes/history/historyItemAggregators/streamStartStop.ts
@@ -6,6 +6,11 @@ import {
   type StreamToppedUp
 } from '../types';
 
+/* 
+  Calculate all timestamps of when a particular stream ran out of funds
+  and insert a history item. Check if the workstream was topped up after,
+  and if yes, also add a top up history item.
+*/
 export const streamStartStop: HistoryAggregator = (_, streams) => {
   const aggregation = Object.values(streams).reduce<{
     outOfFunds: StreamOutOfFunds[];

--- a/src/routes/history/historyItemAggregators/streamUnpaused.ts
+++ b/src/routes/history/historyItemAggregators/streamUnpaused.ts
@@ -1,6 +1,10 @@
 import type { HistoryAggregator } from '../history';
 import { HistoryItemType, type StreamUnpaused } from '../types';
 
+/* 
+  Aggregate all events that add a drip to the recipient after the
+  previous event removed it.
+*/
 export const streamUnpaused: HistoryAggregator = (_, streams) =>
   streams.reduce<StreamUnpaused[]>((acc, ws) => {
     const events = ws.onChainData.dripsUpdatedEvents;

--- a/src/routes/history/historyItemAggregators/streamUnpaused.ts
+++ b/src/routes/history/historyItemAggregators/streamUnpaused.ts
@@ -1,0 +1,38 @@
+import type { HistoryAggregator } from '../history';
+import { HistoryItemType, type StreamUnpaused } from '../types';
+
+export const streamUnpaused: HistoryAggregator = (_, streams) =>
+  streams.reduce<StreamUnpaused[]>((acc, ws) => {
+    const events = ws.onChainData.dripsUpdatedEvents;
+
+    const unpauses = events.filter((dew, index) => {
+      const prevDew = events[index - 1];
+
+      const prevDewPaused =
+        prevDew &&
+        !prevDew.event.args.receivers.find(
+          (r) => r.receiver.toLowerCase() === ws.data.acceptedApplication
+        );
+
+      return (
+        prevDewPaused &&
+        dew.event.args.receivers.find(
+          (r) => r.receiver.toLowerCase() === ws.data.acceptedApplication
+        )
+      );
+    });
+
+    return [
+      ...acc,
+      ...unpauses.map(
+        (dew) =>
+          ({
+            type: HistoryItemType.StreamUnpaused,
+            timestamp: new Date(dew.fromBlock.timestamp * 1000),
+            meta: {
+              workstream: ws
+            }
+          } as StreamUnpaused)
+      )
+    ];
+  }, []);

--- a/src/routes/history/historyItemAggregators/streamedInbetween.ts
+++ b/src/routes/history/historyItemAggregators/streamedInbetween.ts
@@ -1,0 +1,60 @@
+import streamedBetween from '$lib/stores/drips/utils/streamedBetween';
+import { Currency } from '$lib/stores/workstreams/types';
+import type { HistoryAggregator } from '../history';
+import { HistoryItemType } from '../types';
+
+export const streamedInbetween: HistoryAggregator = (queue, streams) => {
+  const newItems = [];
+
+  queue.forEach((item, index) => {
+    const prevItem = queue[index + 1];
+
+    const { timestamp } = item;
+    const prevTimestamp = prevItem?.timestamp || new Date();
+
+    const window = {
+      to: timestamp,
+      from: prevTimestamp
+    };
+
+    const { earned, spent } = streamedBetween(window, streams);
+
+    if (earned.length > 0 || spent.length > 0) {
+      newItems.push({
+        type: HistoryItemType.StreamedInbetween,
+        timestamp: new Date(item.timestamp.getTime() - 1),
+        meta: {
+          earned: {
+            total: {
+              currency: Currency.DAI,
+              wei: earned.reduce<bigint>(
+                (acc, v) => acc + v.amount.wei,
+                BigInt(0)
+              )
+            },
+            streams: earned
+          },
+          spent: {
+            total: {
+              currency: Currency.DAI,
+              wei: spent.reduce<bigint>(
+                (acc, v) => acc + v.amount.wei,
+                BigInt(0)
+              )
+            },
+            streams: spent
+          },
+          secs: Math.floor(
+            window.to.getTime() / 1000 - window.from.getTime() / 1000
+          ),
+          window: {
+            from: window.from,
+            to: window.to
+          }
+        }
+      });
+    }
+  });
+
+  return newItems;
+};

--- a/src/routes/history/historyItemAggregators/streamedInbetween.ts
+++ b/src/routes/history/historyItemAggregators/streamedInbetween.ts
@@ -3,6 +3,10 @@ import { Currency } from '$lib/stores/workstreams/types';
 import type { HistoryAggregator } from '../history';
 import { HistoryItemType } from '../types';
 
+/*
+  Insert an "inbetween" item between subsequent history items, if any funds
+  have been streamed from or to the user within the passed time.
+*/
 export const streamedInbetween: HistoryAggregator = (queue, streams) => {
   const newItems = [];
 

--- a/src/routes/history/historyItemAggregators/today.ts
+++ b/src/routes/history/historyItemAggregators/today.ts
@@ -1,0 +1,51 @@
+import streamedBetween from '$lib/stores/drips/utils/streamedBetween';
+import { Currency } from '$lib/stores/workstreams/types';
+import type { HistoryAggregator } from '../history';
+import { HistoryItemType } from '../types';
+
+export const today: HistoryAggregator = (queue, streams) => {
+  if (queue.length === 0) return [];
+
+  const window = {
+    to: new Date(),
+    from: new Date(
+      queue[0].timestamp.getFullYear(),
+      queue[0].timestamp.getMonth()
+    )
+  };
+
+  const { earned, spent } = streamedBetween(window, streams);
+
+  return [
+    {
+      type: HistoryItemType.MonthStartInbetween,
+      timestamp: new Date(),
+      meta: {
+        earned: {
+          total: {
+            currency: Currency.DAI,
+            wei: earned.reduce<bigint>(
+              (acc, v) => acc + v.amount.wei,
+              BigInt(0)
+            )
+          },
+          streams: earned
+        },
+        spent: {
+          total: {
+            currency: Currency.DAI,
+            wei: spent.reduce<bigint>((acc, v) => acc + v.amount.wei, BigInt(0))
+          },
+          streams: spent
+        },
+        secs: Math.floor(
+          window.to.getTime() / 1000 - window.from.getTime() / 1000
+        ),
+        window: {
+          from: window.from,
+          to: window.to
+        }
+      }
+    }
+  ];
+};

--- a/src/routes/history/historyItemAggregators/today.ts
+++ b/src/routes/history/historyItemAggregators/today.ts
@@ -3,6 +3,10 @@ import { Currency } from '$lib/stores/workstreams/types';
 import type { HistoryAggregator } from '../history';
 import { HistoryItemType } from '../types';
 
+/*
+  Prepend the "Today" headline with a summary of all funds earned
+  and streamed so far in the current month at the top of the history.
+*/
 export const today: HistoryAggregator = (queue, streams) => {
   if (queue.length === 0) return [];
 

--- a/src/routes/history/historyItemAggregators/withdrawal.ts
+++ b/src/routes/history/historyItemAggregators/withdrawal.ts
@@ -1,0 +1,19 @@
+import drips from '$lib/stores/drips';
+import { walletStore } from '$lib/stores/wallet/wallet';
+import { Currency } from '$lib/stores/workstreams/types';
+import { get } from 'svelte/store';
+import type { HistoryAggregator } from '../history';
+import { HistoryItemType } from '../types';
+
+export const withdrawal: HistoryAggregator = () =>
+  get(drips).collectHistory?.map((w) => ({
+    type: HistoryItemType.Withdrawal,
+    timestamp: new Date(w.fromBlock.timestamp * 1000),
+    meta: {
+      amount: {
+        wei: w.event.args.collected.toBigInt(),
+        currency: Currency.DAI
+      },
+      toAddress: get(walletStore).accounts[0]
+    }
+  })) || [];

--- a/src/routes/history/index.svelte
+++ b/src/routes/history/index.svelte
@@ -53,6 +53,10 @@
   }
 </script>
 
+<svelte:head>
+  <title>Workstreams · Account History</title>
+</svelte:head>
+
 <template>
   {#if $connectedAndLoggedIn}
     <h1>Account history</h1>

--- a/src/routes/history/index.svelte
+++ b/src/routes/history/index.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { fly } from 'svelte/transition';
+  import { onDestroy } from 'svelte';
 
   import { workstreamsStore } from '$lib/stores/workstreams';
   import HistoryItem from '$lib/components/History/HistoryItem.svelte';
@@ -10,7 +11,6 @@
   import Spinner from 'radicle-design-system/Spinner.svelte';
   import EmptyState from '$lib/components/EmptyState.svelte';
   import connectedAndLoggedIn from '$lib/stores/connectedAndLoggedIn';
-  import { onDestroy } from 'svelte';
 
   const { estimates } = workstreamsStore;
 

--- a/src/routes/history/index.svelte
+++ b/src/routes/history/index.svelte
@@ -1,0 +1,302 @@
+<script lang="ts">
+  import {
+    type StreamStart,
+    HistoryItemType,
+    type StreamOutOfFunds,
+    type StreamPaused,
+    type StreamToppedUp,
+    type History,
+    type StreamUnpaused
+  } from './types';
+
+  import { walletStore } from '$lib/stores/wallet/wallet';
+  import {
+    workstreamsStore,
+    type DrippingEventWrapper,
+    type EnrichedWorkstream
+  } from '$lib/stores/workstreams';
+  import HistoryItem from '$lib/components/History/HistoryItem.svelte';
+  import { Currency, type Money } from '$lib/stores/workstreams/types';
+
+  $: relevantStreams = Object.entries($workstreamsStore).filter(
+    ([_, ws]) => ws.onChainData
+  );
+
+  let history: History;
+
+  $: {
+    const streamStartItems: StreamStart[] = relevantStreams.map(([_, ws]) => {
+      const timestamp = new Date(
+        ws.onChainData.dripsUpdatedEvents[0].fromBlock.timestamp * 1000
+      );
+
+      return {
+        type: HistoryItemType.StreamStart,
+        timestamp,
+        meta: {
+          workstream: ws
+        }
+      };
+    });
+
+    type StreamStartStopAggregation = {
+      outOfFunds: StreamOutOfFunds[];
+      toppedUp: StreamToppedUp[];
+    };
+    const streamStartStopAggregationItems: StreamStartStopAggregation =
+      relevantStreams.reduce<StreamStartStopAggregation>(
+        (acc, [_, ws]) => {
+          const events = ws.onChainData.dripsUpdatedEvents;
+
+          let newOutOfFundsItems = [];
+          let newToppedUpItems = [];
+
+          events.forEach((wrapper, index) => {
+            const { event, fromBlock } = wrapper;
+            const { receivers, balance } = event.args;
+
+            const amtPerSec = receivers.reduce<bigint>(
+              (acc, r) => acc + r.amtPerSec.toBigInt(),
+              BigInt(0)
+            );
+
+            if (!amtPerSec) {
+              return acc;
+            }
+
+            const nextEvent = events[index + 1];
+            const streamingUntil =
+              fromBlock.timestamp + Number(balance.toBigInt() / amtPerSec);
+            const nextTimestamp =
+              nextEvent?.fromBlock.timestamp || new Date().getTime() / 1000;
+
+            if (streamingUntil > nextTimestamp) {
+              return acc;
+            }
+
+            newOutOfFundsItems = [
+              ...newOutOfFundsItems,
+              {
+                type: HistoryItemType.StreamOutOfFunds,
+                timestamp: new Date(streamingUntil * 1000),
+                meta: {
+                  workstream: ws
+                }
+              }
+            ];
+
+            const wasToppedUpAfter =
+              nextEvent &&
+              nextEvent.event.args.balance.toBigInt() !== BigInt(0);
+
+            newToppedUpItems = wasToppedUpAfter
+              ? [
+                  ...newToppedUpItems,
+                  {
+                    type: HistoryItemType.StreamToppedUp,
+                    timestamp: new Date(nextEvent.fromBlock.timestamp * 1000),
+                    meta: {
+                      workstream: ws
+                    }
+                  }
+                ]
+              : newToppedUpItems;
+          });
+
+          return {
+            outOfFunds: [...acc.outOfFunds, ...newOutOfFundsItems],
+            toppedUp: [...acc.toppedUp, ...newToppedUpItems]
+          };
+        },
+        { outOfFunds: [], toppedUp: [] }
+      );
+
+    const streamPausedItems: StreamPaused[] = relevantStreams.reduce<
+      StreamPaused[]
+    >((acc, [_, ws]) => {
+      const events = ws.onChainData.dripsUpdatedEvents;
+
+      // Get all updates that remove the drip to the recipient
+      const pauses = events.filter(
+        (dew) =>
+          !dew.event.args.receivers.find(
+            (r) => r.receiver.toLowerCase() === $walletStore.accounts[0]
+          )
+      );
+
+      return [
+        ...acc,
+        ...pauses.map(
+          (dew) =>
+            ({
+              type: HistoryItemType.StreamPaused,
+              timestamp: new Date(dew.fromBlock.timestamp * 1000),
+              meta: {
+                workstream: ws
+              }
+            } as StreamPaused)
+        )
+      ];
+    }, []);
+
+    const streamUnpausedEvents: StreamUnpaused[] = relevantStreams.reduce<
+      StreamUnpaused[]
+    >((acc, [wsId, ws]) => {
+      const events = ws.onChainData.dripsUpdatedEvents;
+
+      // Get all updates that remove the drip to the recipient
+      const unpauses = events.filter((dew, index) => {
+        const prevDew: DrippingEventWrapper = events[index - 1];
+
+        const prevDewPaused =
+          prevDew &&
+          !prevDew.event.args.receivers.find(
+            (r) => r.receiver.toLowerCase() === $walletStore.accounts[0]
+          );
+
+        return (
+          prevDewPaused &&
+          dew.event.args.receivers.find(
+            (r) => r.receiver.toLowerCase() === $walletStore.accounts[0]
+          )
+        );
+      });
+
+      return [
+        ...acc,
+        ...unpauses.map(
+          (dew) =>
+            ({
+              type: HistoryItemType.StreamUnpaused,
+              timestamp: new Date(dew.fromBlock.timestamp * 1000),
+              meta: {
+                workstream: ws
+              }
+            } as StreamUnpaused)
+        )
+      ];
+    }, []);
+
+    const allItems: History = [
+      ...streamStartItems,
+      ...streamStartStopAggregationItems.outOfFunds,
+      ...streamStartStopAggregationItems.toppedUp,
+      ...streamPausedItems,
+      ...streamUnpausedEvents
+      // Sort all aggregated history items by timestamp
+    ].sort((a, b) => {
+      if (a.timestamp < b.timestamp) {
+        return 1;
+      }
+      if (a.timestamp > b.timestamp) {
+        return -1;
+      }
+      return 0;
+    });
+
+    allItems.forEach((item, index) => {
+      const prevItem = allItems[index + 1];
+
+      const { timestamp } = item;
+      const prevTimestamp = prevItem?.timestamp || new Date();
+
+      const window = {
+        to: timestamp.getTime() / 1000,
+        from: prevTimestamp.getTime() / 1000
+      };
+
+      let amountsEarned: { workstream: EnrichedWorkstream; amount: Money }[] =
+        [];
+
+      for (const [_, stream] of relevantStreams) {
+        const events = stream.onChainData.dripsUpdatedEvents;
+
+        let amountEarned = BigInt(0);
+
+        events.forEach((dew, index) => {
+          const nextDew = events[index + 1];
+          const validSince = dew.fromBlock.timestamp;
+          const validUntil =
+            nextDew?.fromBlock.timestamp || new Date().getTime() / 1000;
+          const amtPerSec =
+            dew.event.args.receivers[0]?.amtPerSec.toBigInt() || BigInt(0);
+
+          if (amtPerSec === BigInt(0)) return;
+
+          const toppedUpUntil =
+            validSince + Number(dew.event.args.balance.toBigInt() / amtPerSec);
+
+          const relevantWindow = {
+            from: Math.max(validSince, window.from),
+            to: Math.min(window.to, validUntil, toppedUpUntil)
+          };
+
+          const secondsInWindow = Math.max(
+            relevantWindow.to - relevantWindow.from,
+            0
+          );
+          amountEarned = amountEarned + BigInt(secondsInWindow) * amtPerSec;
+        });
+
+        if (amountEarned) {
+          amountsEarned.push({
+            workstream: stream,
+            amount: {
+              currency: Currency.DAI,
+              wei: amountEarned
+            }
+          });
+        }
+      }
+
+      if (amountsEarned.length > 0) {
+        allItems.push({
+          type: HistoryItemType.EarnedInbetween,
+          timestamp: new Date(item.timestamp.getTime() - 1),
+          meta: {
+            earned: amountsEarned,
+            total: {
+              currency: Currency.DAI,
+              wei: amountsEarned.reduce<bigint>(
+                (acc, v) => acc + v.amount.wei,
+                BigInt(0)
+              )
+            },
+            secs: window.to - window.from,
+            window: {
+              from: new Date(window.from * 1000),
+              to: new Date(window.to * 1000)
+            }
+          }
+        });
+      }
+    });
+
+    history = allItems.sort((a, b) => {
+      if (a.timestamp < b.timestamp) {
+        return 1;
+      }
+      if (a.timestamp > b.timestamp) {
+        return -1;
+      }
+      return 0;
+    });
+  }
+</script>
+
+<template>
+  {#if history}
+    <div class="history">
+      {#each history as historyItem}
+        <HistoryItem {historyItem} />
+      {/each}
+    </div>
+  {/if}
+</template>
+
+<style>
+  .history {
+    flex-direction: column;
+    display: flex;
+  }
+</style>

--- a/src/routes/history/types.ts
+++ b/src/routes/history/types.ts
@@ -4,7 +4,7 @@ import type { Money } from '$lib/stores/workstreams/types';
 export enum HistoryItemType {
   MonthStartInbetween,
   Withdrawal,
-  EarnedInbetween,
+  StreamedInbetween,
   StreamStart,
   StreamOutOfFunds,
   StreamPaused,
@@ -19,6 +19,21 @@ export interface HistoryItemBase {
 
 export interface MonthStartInbetween extends HistoryItemBase {
   type: HistoryItemType.MonthStartInbetween;
+  meta: {
+    earned: {
+      total: Money;
+      streams: { workstream: EnrichedWorkstream; amount: Money }[];
+    };
+    spent: {
+      total: Money;
+      streams: { workstream: EnrichedWorkstream; amount: Money }[];
+    };
+    secs: number;
+    window: {
+      from: Date;
+      to: Date;
+    };
+  };
 }
 
 export interface Withdrawal extends HistoryItemBase {
@@ -33,6 +48,7 @@ export interface StreamStart extends HistoryItemBase {
   type: HistoryItemType.StreamStart;
   meta: {
     workstream: EnrichedWorkstream;
+    byAddress: string;
   };
 }
 
@@ -47,6 +63,7 @@ export interface StreamPaused extends HistoryItemBase {
   type: HistoryItemType.StreamPaused;
   meta: {
     workstream: EnrichedWorkstream;
+    byAddress: string;
   };
 }
 
@@ -54,6 +71,8 @@ export interface StreamToppedUp extends HistoryItemBase {
   type: HistoryItemType.StreamToppedUp;
   meta: {
     workstream: EnrichedWorkstream;
+    amount: Money;
+    byAddress: string;
   };
 }
 
@@ -61,14 +80,21 @@ export interface StreamUnpaused extends HistoryItemBase {
   type: HistoryItemType.StreamUnpaused;
   meta: {
     workstream: EnrichedWorkstream;
+    byAddress: string;
   };
 }
 
-export interface EarnedInbetween extends HistoryItemBase {
-  type: HistoryItemType.EarnedInbetween;
+export interface StreamedInbetween extends HistoryItemBase {
+  type: HistoryItemType.StreamedInbetween;
   meta: {
-    earned: { workstream: EnrichedWorkstream; amount: Money }[];
-    total: Money;
+    earned: {
+      total: Money;
+      streams: { workstream: EnrichedWorkstream; amount: Money }[];
+    };
+    spent: {
+      total: Money;
+      streams: { workstream: EnrichedWorkstream; amount: Money }[];
+    };
     secs: number;
     window: {
       from: Date;
@@ -79,7 +105,7 @@ export interface EarnedInbetween extends HistoryItemBase {
 
 export type HistoryItem =
   | MonthStartInbetween
-  | EarnedInbetween
+  | StreamedInbetween
   | Withdrawal
   | StreamStart
   | StreamOutOfFunds

--- a/src/routes/history/types.ts
+++ b/src/routes/history/types.ts
@@ -1,0 +1,90 @@
+import type { EnrichedWorkstream } from '$lib/stores/workstreams';
+import type { Money } from '$lib/stores/workstreams/types';
+
+export enum HistoryItemType {
+  MonthStartInbetween,
+  Withdrawal,
+  EarnedInbetween,
+  StreamStart,
+  StreamOutOfFunds,
+  StreamPaused,
+  StreamUnpaused,
+  StreamToppedUp
+}
+
+export interface HistoryItemBase {
+  timestamp: Date;
+  type: HistoryItemType;
+}
+
+export interface MonthStartInbetween extends HistoryItemBase {
+  type: HistoryItemType.MonthStartInbetween;
+}
+
+export interface Withdrawal extends HistoryItemBase {
+  type: HistoryItemType.Withdrawal;
+  meta: {
+    amount: Money;
+    toAddress: string;
+  };
+}
+
+export interface StreamStart extends HistoryItemBase {
+  type: HistoryItemType.StreamStart;
+  meta: {
+    workstream: EnrichedWorkstream;
+  };
+}
+
+export interface StreamOutOfFunds extends HistoryItemBase {
+  type: HistoryItemType.StreamOutOfFunds;
+  meta: {
+    workstream: EnrichedWorkstream;
+  };
+}
+
+export interface StreamPaused extends HistoryItemBase {
+  type: HistoryItemType.StreamPaused;
+  meta: {
+    workstream: EnrichedWorkstream;
+  };
+}
+
+export interface StreamToppedUp extends HistoryItemBase {
+  type: HistoryItemType.StreamToppedUp;
+  meta: {
+    workstream: EnrichedWorkstream;
+  };
+}
+
+export interface StreamUnpaused extends HistoryItemBase {
+  type: HistoryItemType.StreamUnpaused;
+  meta: {
+    workstream: EnrichedWorkstream;
+  };
+}
+
+export interface EarnedInbetween extends HistoryItemBase {
+  type: HistoryItemType.EarnedInbetween;
+  meta: {
+    earned: { workstream: EnrichedWorkstream; amount: Money }[];
+    total: Money;
+    secs: number;
+    window: {
+      from: Date;
+      to: Date;
+    };
+  };
+}
+
+export type HistoryItem =
+  | MonthStartInbetween
+  | EarnedInbetween
+  | Withdrawal
+  | StreamStart
+  | StreamOutOfFunds
+  | StreamPaused
+  | StreamToppedUp
+  | StreamUnpaused;
+
+export type History = HistoryItem[];


### PR DESCRIPTION
Adds the history view, accessible from the `BalanceButton` dropdown, which aggregates all relevant events to the user and creates a chronological history, including exactly how much was earned or streamed when, and the activity of every incoming or outgoing stream.

<img width="1728" alt="Screenshot 2022-06-10 at 18 12 55" src="https://user-images.githubusercontent.com/1018218/173107832-5dbaacf5-34bf-4982-b203-9e40fe1792aa.png">

