### PR TITLE
Central tick store

### DIFF
--- a/src/lib/components/TopUpSteps/TopUpValues.svelte
+++ b/src/lib/components/TopUpSteps/TopUpValues.svelte
@@ -14,6 +14,7 @@
   import TimeRate from '../TimeRate.svelte';
   import { currencyFormat } from '$lib/utils/format';
   import TextInput from 'radicle-design-system/TextInput.svelte';
+  import tick from '$lib/stores/tick';
 
   const dispatch = createEventDispatcher();
 
@@ -64,10 +65,10 @@
 
   // Also update `streamingUntilAfterTopup` each second
   onMount(() => {
-    const interval = setInterval(updateStreamingUntilAfterTopup, 1000);
+    const interval = tick.register(updateStreamingUntilAfterTopup);
 
     return () => {
-      clearInterval(interval);
+      tick.deregister(interval);
     };
   });
 

--- a/src/lib/stores/tick.ts
+++ b/src/lib/stores/tick.ts
@@ -22,6 +22,10 @@ export default (() => {
     interval.set(undefined);
   }
 
+  function isRunning() {
+    return Boolean(get(interval));
+  }
+
   function register(listener: () => void): number {
     const id = get(listeners).length;
 
@@ -57,6 +61,7 @@ export default (() => {
   return {
     start,
     stop,
+    isRunning,
     register,
     deregister
   };

--- a/src/lib/stores/tick.ts
+++ b/src/lib/stores/tick.ts
@@ -1,0 +1,63 @@
+import { get, writable } from 'svelte/store';
+
+const TICK_INTERVAL_MS = 1000;
+
+export interface TickRegistration {
+  id: number;
+  listener: () => void;
+}
+
+export default (() => {
+  const interval = writable<ReturnType<typeof setInterval>>();
+  const listeners = writable<TickRegistration[]>([]);
+
+  function start() {
+    if (get(interval)) throw 'Tick already running';
+
+    interval.set(setInterval(tick, TICK_INTERVAL_MS));
+  }
+
+  function stop() {
+    clearInterval(get(interval));
+    interval.set(undefined);
+  }
+
+  function register(listener: () => void): number {
+    const id = get(listeners).length;
+
+    const registration = {
+      listener,
+      id
+    };
+
+    listeners.update((v) => [...v, registration]);
+
+    return registration.id;
+  }
+
+  function deregister(registrationId: number): boolean {
+    const currentRegistrations = get(listeners);
+    const registration = currentRegistrations.find(
+      (l) => l.id === registrationId
+    );
+
+    if (!registration) return false;
+
+    listeners.set(currentRegistrations.filter((l) => l.id === registrationId));
+
+    return true;
+  }
+
+  function tick() {
+    for (const registration of get(listeners)) {
+      registration.listener();
+    }
+  }
+
+  return {
+    start,
+    stop,
+    register,
+    deregister
+  };
+})();

--- a/src/lib/stores/workstreams/index.ts
+++ b/src/lib/stores/workstreams/index.ts
@@ -18,6 +18,7 @@ import getDripsUpdatedEvents from './methods/getDripsUpdatedEvents';
 import bigIntMin from './methods/bigIntMin';
 import fetchEstimationWs from './methods/fetchEstimationWs';
 import type { Cycle } from '../drips';
+import tick from '../tick';
 
 export const reviver: (key: string, value: unknown) => unknown = (
   key,
@@ -68,7 +69,7 @@ interface InternalState {
   chainId: number;
   currentCycleStart: Date;
   currentAddress: string;
-  intervalId: NodeJS.Timer;
+  intervalId: number;
 }
 
 interface Estimate {
@@ -90,7 +91,7 @@ export const workstreamsStore = (() => {
   const internal = writable<InternalState | undefined>();
 
   function clear() {
-    clearInterval(get(internal).intervalId);
+    tick.deregister(get(internal).intervalId);
 
     workstreams.set({});
     estimates.set({ streams: {} });
@@ -114,7 +115,7 @@ export const workstreamsStore = (() => {
       chainId: provider.network.chainId,
       currentCycleStart: cycle.start,
       currentAddress: address,
-      intervalId: setInterval(estimateBalances, 1000)
+      intervalId: tick.register(estimateBalances)
     });
 
     await fetchEstimationWs(address);

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -42,13 +42,19 @@
       '(prefers-color-scheme: dark)'
     ).matches;
 
+    const colorSchemeListener = (event: MediaQueryListEvent) => {
+      prefersDarkThemes = event.matches;
+    };
+
     window
       .matchMedia('(prefers-color-scheme: dark)')
-      .addEventListener('change', (event) => {
-        prefersDarkThemes = event.matches;
-      });
+      .addEventListener('change', colorSchemeListener);
 
-    tick.start();
+    if (!tick.isRunning()) tick.start();
+
+    return () => {
+      window.removeEventListener('change', colorSchemeListener);
+    };
   });
 </script>
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
-  import { browser } from '$app/env';
-
-  import { navigating } from '$app/stores';
-  import Header from '$components/Header.svelte';
-  import ModalLayout from '$components/ModalLayout.svelte';
-  import { walletStore } from '$lib/stores/wallet/wallet';
   import { onMount } from 'svelte';
+
   import 'radicle-design-system/static/reset.css';
   import 'radicle-design-system/static/global.css';
   import 'radicle-design-system/static/colors.css';
   import 'radicle-design-system/static/elevation.css';
   import 'radicle-design-system/static/typography.css';
+
+  import { browser } from '$app/env';
+  import { navigating } from '$app/stores';
+  import Header from '$components/Header.svelte';
+  import ModalLayout from '$components/ModalLayout.svelte';
+  import { walletStore } from '$lib/stores/wallet/wallet';
+  import tick from '$lib/stores/tick';
 
   enum Theme {
     DARK = 'dark',
@@ -36,17 +38,17 @@
   $: initialized = $walletStore.initialized;
 
   onMount(() => {
-    if (browser) {
-      prefersDarkThemes = window.matchMedia(
-        '(prefers-color-scheme: dark)'
-      ).matches;
+    prefersDarkThemes = window.matchMedia(
+      '(prefers-color-scheme: dark)'
+    ).matches;
 
-      window
-        .matchMedia('(prefers-color-scheme: dark)')
-        .addEventListener('change', (event) => {
-          prefersDarkThemes = event.matches;
-        });
-    }
+    window
+      .matchMedia('(prefers-color-scheme: dark)')
+      .addEventListener('change', (event) => {
+        prefersDarkThemes = event.matches;
+      });
+
+    tick.start();
   });
 </script>
 

--- a/src/routes/history/index.svelte
+++ b/src/routes/history/index.svelte
@@ -11,6 +11,7 @@
   import Spinner from 'radicle-design-system/Spinner.svelte';
   import EmptyState from '$lib/components/EmptyState.svelte';
   import connectedAndLoggedIn from '$lib/stores/connectedAndLoggedIn';
+  import tick from '$lib/stores/tick';
 
   const { estimates } = workstreamsStore;
 
@@ -19,7 +20,7 @@
   );
 
   let loading = true;
-  let interval: ReturnType<typeof setInterval>;
+  let tickRegistrationId: number;
 
   $: {
     if (
@@ -29,14 +30,14 @@
     ) {
       updateHistory();
       loading = false;
-      clearInterval(interval);
-      interval = setInterval(updateHistory, 1000);
+      tick.deregister(tickRegistrationId);
+      tickRegistrationId = tick.register(updateHistory);
     } else {
-      clearInterval(interval);
+      tick.deregister(tickRegistrationId);
     }
   }
 
-  onDestroy(() => clearInterval(interval));
+  onDestroy(() => tick.deregister(tickRegistrationId));
 
   function updateHistory() {
     history


### PR DESCRIPTION
Adds a new `tick` store for registering and unregistering functions that should be ran periodically. This avoids many different intervals being set for the now-many places where we want something to be recalculated once a second. Like this, all places of the UI will update in the exact same moment, rather than staggered based on when their respective interval was set, and we can centrally control the tick rate.