### PR TITLE
feat: Show only active streams from current chain & support Mainnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@fontsource/fira-mono": "^4.5.7",
     "@lukeed/uuid": "^2.0.0",
-    "drips-sdk": "https://github.com/radicle-dev/drips-js-sdk#v0.1.1",
+    "drips-sdk": "https://github.com/radicle-dev/drips-js-sdk#973599caf3013a2ac56155f11b8cd2426ff263d1",
     "ethers": "5.6.4",
     "graphql-tag": "^2.12.6",
     "radicle-design-system": "radicle-dev/radicle-upstream#workspace=radicle-design-system&commit=b451660c33609180928b0776707553d4ea8f7156",

--- a/src/lib/stores/drips/index.ts
+++ b/src/lib/stores/drips/index.ts
@@ -64,7 +64,6 @@ export default (() => {
   const state = writable<DripsState>({});
 
   async function connect(provider: ethers.providers.Web3Provider) {
-    console.log(provider.network.chainId);
     const client = new DripsClient(
       provider,
       networkNameMap[provider.network.chainId]
@@ -141,12 +140,10 @@ export default (() => {
   async function updateCollectable(): Promise<void> {
     const { client, provider } = get(internal);
 
-    console.log('get collectable');
     const collectable = await client.getAmountCollectableWithSplits(
       await provider.getSigner().getAddress(),
       []
     );
-    console.log('done');
 
     state.update((v) => ({
       ...v,

--- a/src/lib/stores/drips/index.ts
+++ b/src/lib/stores/drips/index.ts
@@ -53,12 +53,22 @@ export const toDai = (wei: BigNumber, roundTo?: number): string => {
   return round(dai, roundTo);
 };
 
+// https://github.com/radicle-dev/drips-js-sdk/issues/34
+const networkNameMap = {
+  1: 'mainnet',
+  4: 'rinkeby'
+};
+
 export default (() => {
   const internal = writable<InternalState | undefined>(undefined);
   const state = writable<DripsState>({});
 
   async function connect(provider: ethers.providers.Web3Provider) {
-    const client = new DripsClient(provider);
+    console.log(provider.network.chainId);
+    const client = new DripsClient(
+      provider,
+      networkNameMap[provider.network.chainId]
+    );
     await client.connect();
 
     internal.set({
@@ -131,10 +141,12 @@ export default (() => {
   async function updateCollectable(): Promise<void> {
     const { client, provider } = get(internal);
 
+    console.log('get collectable');
     const collectable = await client.getAmountCollectableWithSplits(
       await provider.getSigner().getAddress(),
       []
     );
+    console.log('done');
 
     state.update((v) => ({
       ...v,

--- a/src/lib/stores/workstreams/types.ts
+++ b/src/lib/stores/workstreams/types.ts
@@ -32,6 +32,7 @@ export interface Workstream {
   desc: string;
   dripsData?: {
     accountId: number;
+    chainId: number;
   };
   applicants?: string[];
 }

--- a/src/routes/profile/[address].svelte
+++ b/src/routes/profile/[address].svelte
@@ -16,8 +16,8 @@
 
     return {
       props: {
-        createdWorkstreams: responses[0].ok && responses[0].data,
-        assignedWorkstreams: responses[1].ok && responses[1].data
+        createdWorkstreams: responses[0].ok ? responses[0].data : [],
+        assignedWorkstreams: responses[1].ok ? responses[1].data : []
       }
     };
   }
@@ -35,9 +35,18 @@
   import Section from '$lib/components/Section.svelte';
   import ExploreCard from '$components/ExploreCard.svelte';
   import EmptyState from '$components/EmptyState.svelte';
+  import connectedAndLoggedIn from '$lib/stores/connectedAndLoggedIn';
+  import { walletStore } from '$lib/stores/wallet/wallet';
 
   export let createdWorkstreams: Workstream[] = [];
   export let assignedWorkstreams: Workstream[] = [];
+
+  console.log(assignedWorkstreams);
+  $: assignedWorkstreamsOnCurrentChain = $connectedAndLoggedIn
+    ? assignedWorkstreams.filter(
+        (w) => w.dripsData.chainId === $walletStore.chainId
+      )
+    : assignedWorkstreams;
 
   const formatAddress = (addr?: string | undefined) => {
     if (addr) {
@@ -62,7 +71,7 @@
   {#if utils.isAddress($page.params.address)}
     <UserBig address={$page.params.address} />
     <div class="overview">
-      {#if !assignedWorkstreams && !createdWorkstreams}
+      {#if !assignedWorkstreamsOnCurrentChain && !createdWorkstreams}
         <EmptyState
           emoji="👀"
           headerText="Nothing to see here"
@@ -71,13 +80,13 @@
           on:primaryAction={() => goto(`/`)}
         />
       {:else}
-        {#if assignedWorkstreams?.length > 0}
+        {#if assignedWorkstreamsOnCurrentChain?.length > 0}
           <Section
             title="Assigned workstreams"
-            count={assignedWorkstreams.length}
+            count={assignedWorkstreamsOnCurrentChain.length}
           >
             <div slot="content" class="workstreams">
-              {#each assignedWorkstreams as workstream}
+              {#each assignedWorkstreamsOnCurrentChain as workstream}
                 <ExploreCard {workstream} />
               {/each}
             </div>

--- a/src/routes/profile/[address].svelte
+++ b/src/routes/profile/[address].svelte
@@ -41,7 +41,6 @@
   export let createdWorkstreams: Workstream[] = [];
   export let assignedWorkstreams: Workstream[] = [];
 
-  console.log(assignedWorkstreams);
   $: assignedWorkstreamsOnCurrentChain = $connectedAndLoggedIn
     ? assignedWorkstreams.filter(
         (w) => w.dripsData.chainId === $walletStore.chainId

--- a/yarn.lock
+++ b/yarn.lock
@@ -2714,12 +2714,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"drips-sdk@https://github.com/radicle-dev/drips-js-sdk#v0.1.1":
+"drips-sdk@https://github.com/radicle-dev/drips-js-sdk#973599caf3013a2ac56155f11b8cd2426ff263d1":
   version: 0.1.1
-  resolution: "drips-sdk@https://github.com/radicle-dev/drips-js-sdk.git#commit=234af1b9f633dd8decb8e7f502e9d34ef344a08e"
+  resolution: "drips-sdk@https://github.com/radicle-dev/drips-js-sdk.git#commit=973599caf3013a2ac56155f11b8cd2426ff263d1"
   peerDependencies:
     ethers: ^5.6.2
-  checksum: 6c364c11aa29a5cda79ab8a38e4e5847d3860cefd7c4d366a1aa90aa2d3c7ea4ac22e73609973216be82c92a8667cdf2d357d2ef97b4a4ce20364dd99a5a43cf
+  checksum: 179ab3633444f02d326b9cd1fea0b07ad1f8c3dd785207f2c7728ceaaf7016edf60f68fd579eb3c97c01328888e8bdf3eb54edd56ee0c03ce35064f7852793ff
   languageName: node
   linkType: hard
 
@@ -7362,7 +7362,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.20.0
     "@typescript-eslint/parser": ^5.20.0
     apollo: ^2.33.11
-    drips-sdk: "https://github.com/radicle-dev/drips-js-sdk#v0.1.1"
+    drips-sdk: "https://github.com/radicle-dev/drips-js-sdk#973599caf3013a2ac56155f11b8cd2426ff263d1"
     eslint: ^8.13.0
     eslint-config-prettier: ^8.5.0
     eslint-plugin-svelte3: ^3.4.1


### PR DESCRIPTION
Resolves #123

Filters out any fetched active workstreams in `workstreamsStore` and on the profile page if they are not set up on the current network. Effectively, this means the history, dashboard and someone's profile are now displaying only data from the selected network, and users can have both test streams and real streams on the same address at the same time.

Also changes to a multi-network version of the drips sdk, making it possible to create streams on mainnet.