### PR TITLE
fix: UI reactivity after API interactions

### DIFF
--- a/src/lib/components/ApplicationModal.svelte
+++ b/src/lib/components/ApplicationModal.svelte
@@ -57,15 +57,6 @@
         `${getConfig().API_URL_BASE}/workstreams/${workstream.id}/applications`
       );
 
-      if (decision === 'accept') {
-        // Refresh fetched workstream so it appears in its new state.
-        await invalidate(
-          `${getConfig().API_URL_BASE}/workstreams/${
-            workstream.id
-          }/applications`
-        );
-      }
-
       modal.hide();
     } catch (e) {
       console.error(e);

--- a/src/lib/components/ApplyModal.svelte
+++ b/src/lib/components/ApplyModal.svelte
@@ -19,6 +19,7 @@
   import Dropdown from 'radicle-design-system/Dropdown.svelte';
   import { weiToDai } from '$lib/utils/format';
   import { getConfig } from '$lib/config';
+  import { invalidate } from '$app/navigation';
 
   export let workstream: Workstream;
 
@@ -64,6 +65,11 @@
                 : undefined
           } as ApplicationInput)
         }
+      );
+
+      // Refresh fetched applications so the new application shows up.
+      await invalidate(
+        `${getConfig().API_URL_BASE}/workstreams/${workstream.id}/applications`
       );
     } catch (e) {
       return;

--- a/src/lib/components/CreateModal.svelte
+++ b/src/lib/components/CreateModal.svelte
@@ -8,9 +8,13 @@
   import TextInput from 'radicle-design-system/TextInput.svelte';
   import TextArea from 'radicle-design-system/TextArea.svelte';
   import { getConfig } from '$lib/config';
-  import type { WorkstreamInput } from '$lib/stores/workstreams/types';
-  import { goto } from '$app/navigation';
+  import type {
+    Workstream,
+    WorkstreamInput
+  } from '$lib/stores/workstreams/types';
   import { utils } from 'ethers';
+  import { workstreamsStore } from '$lib/stores/workstreams';
+  import { walletStore } from '$lib/stores/wallet/wallet';
 
   const durationOptions = [
     { value: '1', title: 'Days' },
@@ -43,7 +47,7 @@
     const weiPerSecond = weiPerDay.div(86400);
 
     try {
-      await fetch(`${getConfig().API_URL_BASE}/workstreams`, {
+      const res = await fetch(`${getConfig().API_URL_BASE}/workstreams`, {
         method: 'POST',
         credentials: 'include',
         body: JSON.stringify({
@@ -56,10 +60,15 @@
           durationDays: parseInt(duration) * parseInt(durationUnit)
         } as WorkstreamInput)
       });
+
+      const workstream: Workstream = await res.json();
+
+      // Push the new workstream into the state so it shows up on the dashboard.
+      await workstreamsStore.getWorkstream(workstream.id);
     } catch (e) {
       return;
     }
-    goto('/dashboard');
+
     modal.hide();
   }
 </script>

--- a/src/lib/components/CreateModal.svelte
+++ b/src/lib/components/CreateModal.svelte
@@ -14,7 +14,6 @@
   } from '$lib/stores/workstreams/types';
   import { utils } from 'ethers';
   import { workstreamsStore } from '$lib/stores/workstreams';
-  import { walletStore } from '$lib/stores/wallet/wallet';
 
   const durationOptions = [
     { value: '1', title: 'Days' },

--- a/src/lib/components/StepperModal/index.svelte
+++ b/src/lib/components/StepperModal/index.svelte
@@ -28,7 +28,6 @@
       currentStep = steps[currentStepIndex];
     } else {
       modal.hide();
-      goto($page.url.pathname);
     }
   }
 
@@ -42,7 +41,6 @@
       currentStep = steps[currentStepIndex];
     } else {
       modal.hide();
-      goto($page.url.pathname);
     }
   }
 

--- a/src/lib/components/StepperModal/index.svelte
+++ b/src/lib/components/StepperModal/index.svelte
@@ -5,8 +5,6 @@
   import { onMount, type SvelteComponent } from 'svelte';
   import Spinner from 'radicle-design-system/Spinner.svelte';
 
-  import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
   import WaitPromise from './WaitPromiseStep.svelte';
   import type { AwaitPendingPayload } from './types';
 

--- a/src/lib/components/TopUpSteps/TopUpValues.svelte
+++ b/src/lib/components/TopUpSteps/TopUpValues.svelte
@@ -29,7 +29,7 @@
   let topUpAmount = 1;
   $: topUpAmountWei = toWei(topUpAmount || 0).toBigInt();
 
-  $: estimate = $estimates.streams[enrichedWorkstream.data.id];
+  $: estimate = $estimates.workstreams[enrichedWorkstream.data.id];
   $: streamingUntil = estimate?.streamingUntil;
   $: currAmtPerSec = enrichedWorkstream.onChainData.amtPerSec.wei;
   $: remainingBalance = estimate?.remainingBalance;

--- a/src/lib/components/WorkstreamCard/index.svelte
+++ b/src/lib/components/WorkstreamCard/index.svelte
@@ -23,7 +23,7 @@
 
   $: ws = enrichedWorkstream?.data || workstream;
   $: onChainData = enrichedWorkstream?.onChainData;
-  $: estimate = $estimates.streams[ws.id];
+  $: estimate = $estimates.workstreams[ws.id];
 
   $: onChainDataReady = Boolean(estimate);
 

--- a/src/lib/components/WorkstreamDetail/ActiveStream.svelte
+++ b/src/lib/components/WorkstreamDetail/ActiveStream.svelte
@@ -22,7 +22,7 @@
   const estimates = workstreamsStore.estimates;
   $: estimate = $estimates.streams[workstream.id];
 
-  $: enrichedWorkstream = $workstreamsStore[workstream.id];
+  $: enrichedWorkstream = $workstreamsStore.workstreams[workstream.id];
   $: isOwner = workstream.creator === $walletStore.address;
   $: isReceiver = workstream.acceptedApplication === $walletStore.address;
   $: activeSince =

--- a/src/lib/components/WorkstreamDetail/ActiveStream.svelte
+++ b/src/lib/components/WorkstreamDetail/ActiveStream.svelte
@@ -32,11 +32,19 @@
         .timestamp * 1000
     );
 
+  function refreshStream() {
+    workstreamsStore.getWorkstream(enrichedWorkstream.data.id);
+  }
+
   function pauseUnpause(action: 'pause' | 'unpause') {
     modal.show(
       StepperModal,
       async () => {
-        await workstreamsStore.getWorkstream(workstream.id, undefined, true);
+        await workstreamsStore.getWorkstream(
+          workstream.id,
+          () => refreshStream(),
+          true
+        );
       },
       {
         steps: [
@@ -52,7 +60,7 @@
   }
 
   function topUp() {
-    modal.show(StepperModal, undefined, {
+    modal.show(StepperModal, () => refreshStream(), {
       stepProps: {
         enrichedWorkstream
       },

--- a/src/lib/components/WorkstreamDetail/ActiveStream.svelte
+++ b/src/lib/components/WorkstreamDetail/ActiveStream.svelte
@@ -20,7 +20,7 @@
   export let acceptedApplication: Application | undefined = undefined;
 
   const estimates = workstreamsStore.estimates;
-  $: estimate = $estimates.streams[workstream.id];
+  $: estimate = $estimates.workstreams[workstream.id];
 
   $: enrichedWorkstream = $workstreamsStore.workstreams[workstream.id];
   $: isOwner = workstream.creator === $walletStore.address;
@@ -37,26 +37,16 @@
   }
 
   function pauseUnpause(action: 'pause' | 'unpause') {
-    modal.show(
-      StepperModal,
-      async () => {
-        await workstreamsStore.getWorkstream(
-          workstream.id,
-          () => refreshStream(),
-          true
-        );
-      },
-      {
-        steps: [
-          PauseUnpauseStep,
-          $walletStore.safe?.ready && AwaitingSafeTransactionStep
-        ],
-        stepProps: {
-          enrichedWorkstream,
-          action
-        }
+    modal.show(StepperModal, () => refreshStream(), {
+      steps: [
+        PauseUnpauseStep,
+        $walletStore.safe?.ready && AwaitingSafeTransactionStep
+      ],
+      stepProps: {
+        enrichedWorkstream,
+        action
       }
-    );
+    });
   }
 
   function topUp() {

--- a/src/lib/components/WorkstreamDetail/ApplicationList.svelte
+++ b/src/lib/components/WorkstreamDetail/ApplicationList.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import * as modal from '$lib/utils/modal';
-  import { getConfig } from '$lib/config';
 
   import ApplicationModal from '$components/ApplicationModal.svelte';
   import Card from '$components/Card.svelte';
@@ -8,7 +7,6 @@
   import Row from '$components/Row.svelte';
   import Rate from '$components/Rate.svelte';
   import Button from 'radicle-design-system/Button.svelte';
-  import ThumbsDown from 'radicle-design-system/icons/ThumbsDown.svelte';
   import TokenStreams from 'radicle-design-system/icons/TokenStreams.svelte';
 
   import {

--- a/src/lib/components/WorkstreamDetail/ApplicationList.svelte
+++ b/src/lib/components/WorkstreamDetail/ApplicationList.svelte
@@ -31,7 +31,6 @@
   export let applications: Application[];
   export let style = '';
   export let title = '';
-  export let creator: boolean | undefined = undefined;
   export let accepted: boolean | undefined = undefined;
 
   let actionsDisabled = false;
@@ -44,22 +43,6 @@
         GnosisSafeWaitingForConfirmationStep
       ]
     : [IntroStep, SetDaiAllowanceStep, ConfirmValuesStep];
-
-  async function rejectApplication(id: string) {
-    actionsDisabled = true;
-    try {
-      await fetch(
-        `${getConfig().API_URL_BASE}/workstreams/${
-          workstream.id
-        }/applications/${id}/reject`,
-        { method: 'POST', credentials: 'include' }
-      );
-    } catch (e) {
-      return;
-    } finally {
-      actionsDisabled = false;
-    }
-  }
 </script>
 
 <Card hoverable={false} {style}>
@@ -87,14 +70,7 @@
               </p>
             {/if}
           {/if}
-          {#if creator && !accepted}
-            <Button
-              disabled={actionsDisabled}
-              on:click={() => rejectApplication(application.id)}
-              variant="primary-outline"
-              icon={ThumbsDown}>Deny</Button
-            >
-          {:else if accepted}
+          {#if accepted}
             <Button
               disabled={actionsDisabled}
               on:click={() =>

--- a/src/lib/components/WorkstreamDetail/index.svelte
+++ b/src/lib/components/WorkstreamDetail/index.svelte
@@ -21,14 +21,12 @@
   let openApplications: Application[] | undefined = undefined;
   let rejectedApplications: Application[] | undefined = undefined;
 
-  let applied = false;
-  let creator: boolean =
+  $: applied =
+    $walletStore.ready && workstream.applicants?.includes($walletStore.address);
+  $: creator =
     $walletStore.ready && workstream.creator === $walletStore.address;
 
   $: {
-    applied =
-      $walletStore.ready &&
-      workstream.applicants?.includes($walletStore.address);
     if (applications) {
       acceptedApplication = applications.find(
         (application) => application.state === ApplicationState.ACCEPTED

--- a/src/lib/components/WorkstreamDetail/index.svelte
+++ b/src/lib/components/WorkstreamDetail/index.svelte
@@ -58,7 +58,6 @@
         applications={[acceptedApplication]}
         title="Accepted applications"
         {workstream}
-        {creator}
         accepted={creator}
       />
     {:else}
@@ -68,7 +67,6 @@
       <ApplicationList
         applications={openApplications}
         title="Open applications"
-        {creator}
         {workstream}
       />
     {/if}

--- a/src/lib/stores/wallet/wallet.ts
+++ b/src/lib/stores/wallet/wallet.ts
@@ -308,8 +308,6 @@ export const walletStore = (() => {
     }));
   }
 
-  state.subscribe((s) => console.log(s));
-
   async function disconnect() {
     await _logOut();
     _wipeStoredLogin();

--- a/src/lib/stores/wallet/wallet.ts
+++ b/src/lib/stores/wallet/wallet.ts
@@ -123,7 +123,7 @@ export const walletStore = (() => {
     state.set({
       metamaskInstalled: Boolean(detectedWindowProvider),
       accounts: (accounts && prepareAccounts(accounts)) || [],
-      address: accounts?.[0]?.toLowerCase(),
+      address: login && accounts?.[0]?.toLowerCase(),
       walletType: detectedWindowProvider ? 'metamask' : undefined,
       login,
       provider,
@@ -308,6 +308,8 @@ export const walletStore = (() => {
     }));
   }
 
+  state.subscribe((s) => console.log(s));
+
   async function disconnect() {
     await _logOut();
     _wipeStoredLogin();
@@ -315,6 +317,7 @@ export const walletStore = (() => {
     state.update((s) => ({
       ...s,
       safe: undefined,
+      address: undefined,
       accounts: [],
       walletType: undefined,
       login: undefined,

--- a/src/lib/stores/workstreams/index.ts
+++ b/src/lib/stores/workstreams/index.ts
@@ -87,18 +87,11 @@ interface Estimate {
 }
 
 interface EstimatesState {
-  streams: { [wsId: string]: Estimate };
+  workstreams: { [wsId: string]: Estimate };
   totalBalance?: Money;
-  /**
-   * Indicates whether all relevant streams for estimation
-   * have been sucessfully fetched, and the estimation
-   * is considered accurate. Before this is true, don't
-   * rely on the totalBalance value.
-   */
-  activeStreamsFetched: boolean;
 }
 
-const INITIAL_STATE = {
+const INITIAL_WORKSTREAMS_STATE = {
   fetchStatus: {
     relevantStreamsFetched: false,
     relevantStreamsFetching: true
@@ -107,18 +100,17 @@ const INITIAL_STATE = {
 };
 
 export const workstreamsStore = (() => {
-  const workstreams = writable<WorkstreamsState>(INITIAL_STATE);
+  const workstreams = writable<WorkstreamsState>(INITIAL_WORKSTREAMS_STATE);
   const estimates = writable<EstimatesState>({
-    streams: {},
-    activeStreamsFetched: false
+    workstreams: {}
   });
   const internal = writable<InternalState | undefined>();
 
   function clear() {
     tick.deregister(get(internal).intervalId);
 
-    workstreams.set(INITIAL_STATE);
-    estimates.set({ streams: {}, activeStreamsFetched: false });
+    workstreams.set(INITIAL_WORKSTREAMS_STATE);
+    estimates.set({ workstreams: {} });
     internal.set(undefined);
   }
 
@@ -157,11 +149,6 @@ export const workstreamsStore = (() => {
           relevantStreamsFetching: false,
           relevantStreamsFetched: true
         }
-      }));
-
-      estimates.update((v) => ({
-        ...v,
-        activeStreamsFetched: true
       }));
     } catch {
       workstreams.update((v) => ({
@@ -365,13 +352,12 @@ export const workstreamsStore = (() => {
     );
 
     estimates.update((estimatesVal) => ({
-      ...estimatesVal,
       totalBalance: {
         wei: totalWeiEarned,
         currency: Currency.DAI
       },
-      streams: {
-        ...estimatesVal.streams,
+      workstreams: {
+        ...estimatesVal.workstreams,
         ...newEstimates
       }
     }));

--- a/src/lib/stores/workstreams/methods/fetchRelevantWorkstreams.ts
+++ b/src/lib/stores/workstreams/methods/fetchRelevantWorkstreams.ts
@@ -1,7 +1,6 @@
 import { workstreamsStore } from '..';
 
 export default async function (address: string) {
-  console.log('fetching');
   return await Promise.all([
     await workstreamsStore.getWorkstreams({
       assignedTo: address

--- a/src/lib/stores/workstreams/methods/fetchRelevantWorkstreams.ts
+++ b/src/lib/stores/workstreams/methods/fetchRelevantWorkstreams.ts
@@ -1,12 +1,14 @@
 import { workstreamsStore } from '..';
 
 export default async function (address: string) {
+  console.log('fetching');
   return await Promise.all([
     await workstreamsStore.getWorkstreams({
       assignedTo: address
     }),
     await workstreamsStore.getWorkstreams({
       createdBy: address
-    })
+    }),
+    await workstreamsStore.getWorkstreams({ applied: 'true' })
   ]);
 }

--- a/src/routes/dashboard/index.svelte
+++ b/src/routes/dashboard/index.svelte
@@ -128,7 +128,7 @@
     filterObject($workstreamsStore.workstreams, (ws) => {
       return (
         ws.data.acceptedApplication === $walletStore.address &&
-        $estimates.streams[ws.data.id]?.currentlyStreaming
+        $estimates.workstreams[ws.data.id]?.currentlyStreaming
       );
     })
   );
@@ -137,7 +137,7 @@
     filterObject($workstreamsStore.workstreams, (ws) => {
       return (
         ws.data.creator === $walletStore.address &&
-        $estimates.streams[ws.data.id]?.currentlyStreaming
+        $estimates.workstreams[ws.data.id]?.currentlyStreaming
       );
     })
   );
@@ -147,7 +147,7 @@
   }) {
     const totalWeiPerSec = Object.entries(enrichedWorkstreams).reduce<bigint>(
       (acc, [id, ws]) => {
-        return $estimates.streams[id]?.currentlyStreaming
+        return $estimates.workstreams[id]?.currentlyStreaming
           ? acc + ws.onChainData.amtPerSec.wei
           : acc;
       },

--- a/src/routes/dashboard/index.svelte
+++ b/src/routes/dashboard/index.svelte
@@ -17,6 +17,7 @@
   } from '$lib/stores/workstreams';
   import { goto } from '$app/navigation';
   import Spinner from 'radicle-design-system/Spinner.svelte';
+  import { onMount } from 'svelte';
 
   const estimates = workstreamsStore.estimates;
 
@@ -35,27 +36,9 @@
     workstreams: { [wsId: string]: EnrichedWorkstream };
   }
 
-  let loading = true;
+  onMount(workstreamsStore.refreshRelevantStreams);
 
-  $: {
-    if ($walletStore.ready) {
-      loading = true;
-
-      const fetches = [
-        workstreamsStore.getWorkstreams({ applied: 'true' }),
-        workstreamsStore.getWorkstreams({
-          createdBy: $walletStore.address
-        }),
-        workstreamsStore.getWorkstreams({
-          assignedTo: $walletStore.address
-        })
-      ];
-
-      Promise.all(fetches).then(() => (loading = false));
-    }
-  }
-
-  $: workstreams = $workstreamsStore;
+  $: workstreams = $workstreamsStore.workstreams;
 
   function filterObject<T>(
     obj: { [key: string]: T },
@@ -142,7 +125,7 @@
   } as Sections;
 
   $: incomingTotal = calculateStreamTotal(
-    filterObject($workstreamsStore, (ws) => {
+    filterObject($workstreamsStore.workstreams, (ws) => {
       return (
         ws.data.acceptedApplication === $walletStore.address &&
         $estimates.streams[ws.data.id]?.currentlyStreaming
@@ -151,7 +134,7 @@
   );
 
   $: outgoingTotal = calculateStreamTotal(
-    filterObject($workstreamsStore, (ws) => {
+    filterObject($workstreamsStore.workstreams, (ws) => {
       return (
         ws.data.creator === $walletStore.address &&
         $estimates.streams[ws.data.id]?.currentlyStreaming
@@ -226,7 +209,7 @@
           </Section>
         </div>
       {/each}
-      {#if loading}
+      {#if $workstreamsStore.fetchStatus.relevantStreamsFetching}
         <div transition:fly|local={{ y: 10, duration: 300 }} class="spinner">
           <Spinner />
         </div>

--- a/src/routes/history/index.svelte
+++ b/src/routes/history/index.svelte
@@ -23,7 +23,10 @@
   let tickRegistrationId: number;
 
   $: {
-    if ($walletStore.ready && $estimates.activeStreamsFetched) {
+    if (
+      $walletStore.ready &&
+      $workstreamsStore.fetchStatus.relevantStreamsFetched
+    ) {
       updateHistory();
       loading = false;
       tick.deregister(tickRegistrationId);

--- a/src/routes/history/index.svelte
+++ b/src/routes/history/index.svelte
@@ -15,7 +15,7 @@
 
   const { estimates } = workstreamsStore;
 
-  $: relevantStreams = Object.values($workstreamsStore).filter(
+  $: relevantStreams = Object.values($workstreamsStore.workstreams).filter(
     (ws) => ws.onChainData
   );
 


### PR DESCRIPTION
Ensures reactivity of UI after performing a number of actions.

- Workstreams now immediately appear after creating them using the workstream creation modal.
- Applications now immediately appear on the Workstream Detail View after submitting the Application Create modal.
- The results of on-chain interactions such as pausing, unpausing and topping up a stream now are now immediately visible on the dashboard & workstream detail views.
- Application accept / reject buttons now appear & disappear accordingly when switching between the creator account and an arbitrary other account.
- After accepting or a rejecting an application, the workstream detail view now immediately updates accordingly.

Resolves #142