### PR TITLE
Remove pending state

### DIFF
--- a/src/lib/components/CreateModal.svelte
+++ b/src/lib/components/CreateModal.svelte
@@ -121,6 +121,7 @@
       },
       title,
       desc: description,
+      chainId: $walletStore.network.chainId,
       durationDays: parseInt(duration) * parseInt(durationUnit)
     };
 
@@ -128,7 +129,7 @@
       input = {
         ...input,
         assignTo: assigneeAddress,
-        state: WorkstreamState.PENDING
+        state: WorkstreamState.ACTIVE
       };
     }
 

--- a/src/lib/components/SetUpPaymentSteps/steps/ConfirmValues.svelte
+++ b/src/lib/components/SetUpPaymentSteps/steps/ConfirmValues.svelte
@@ -45,7 +45,11 @@
     actionInFlight = true;
 
     try {
-      const accountId = drips.getRandomAccountId();
+      const accountId = workstream.dripsData?.accountId;
+
+      if (!accountId) {
+        throw new Error('Unable to find Drips account ID for workstream.');
+      }
 
       const createDripCall = await drips.createDrip(
         workstream.acceptedApplication,
@@ -63,15 +67,6 @@
         if (receipt.status === 0) {
           console.error(receipt);
           return;
-        }
-
-        const activateCall = await workstreamsStore.activateWorkstream(
-          workstream.id,
-          accountId
-        );
-
-        if (!activateCall.ok) {
-          throw new Error(activateCall.error);
         }
 
         await invalidate(

--- a/src/lib/components/SetUpPaymentSteps/steps/ConfirmValues.svelte
+++ b/src/lib/components/SetUpPaymentSteps/steps/ConfirmValues.svelte
@@ -8,7 +8,6 @@
   import { Currency, type Workstream } from '$lib/stores/workstreams/types';
   import { currencyFormat, weiToDai } from '$lib/utils/format';
   import ButtonRow from '../components/ButtonRow.svelte';
-  import { workstreamsStore } from '$lib/stores/workstreams';
   import { utils } from 'ethers';
   import { getConfig } from '$lib/config';
   import { invalidate } from '$app/navigation';

--- a/src/lib/components/SetUpPaymentSteps/steps/gnosis-safe/ConfirmValues.svelte
+++ b/src/lib/components/SetUpPaymentSteps/steps/gnosis-safe/ConfirmValues.svelte
@@ -45,7 +45,11 @@
     actionInFlight = true;
 
     try {
-      const accountId = drips.getRandomAccountId();
+      const accountId = workstream.dripsData?.accountId;
+
+      if (!accountId) {
+        throw new Error('Unable to find Drips account ID for workstream.');
+      }
 
       const waitFor = async () => {
         drips.createDrip(
@@ -56,19 +60,6 @@
           },
           accountId,
           utils.parseUnits(topUpAmount.toString()).toBigInt()
-        );
-
-        const activateCall = await workstreamsStore.activateWorkstream(
-          workstream.id,
-          accountId
-        );
-
-        if (!activateCall.ok) {
-          throw new Error(activateCall.error);
-        }
-
-        await invalidate(
-          `${getConfig().API_URL_BASE}/workstreams/${workstream.id}`
         );
       };
 

--- a/src/lib/components/SetUpPaymentSteps/steps/gnosis-safe/ConfirmValues.svelte
+++ b/src/lib/components/SetUpPaymentSteps/steps/gnosis-safe/ConfirmValues.svelte
@@ -8,10 +8,7 @@
   import { Currency, type Workstream } from '$lib/stores/workstreams/types';
   import { currencyFormat, weiToDai } from '$lib/utils/format';
   import ButtonRow from '../../components/ButtonRow.svelte';
-  import { workstreamsStore } from '$lib/stores/workstreams';
   import { utils } from 'ethers';
-  import { invalidate } from '$app/navigation';
-  import { getConfig } from '$lib/config';
 
   const dispatch = createEventDispatcher();
 

--- a/src/lib/components/SetUpPaymentSteps/steps/gnosis-safe/WaitingForConfirmation.svelte
+++ b/src/lib/components/SetUpPaymentSteps/steps/gnosis-safe/WaitingForConfirmation.svelte
@@ -12,10 +12,11 @@
   <span slot="headline">Continue in your Gnosis Safe</span>
   <div slot="content">
     <p>
-      Your workstream has been activated, but it won't start streaming funds
-      until the transaction reaches quorum and is executed by your Gnosis Safe.
-      Head over to your safe now, sign the transaction, and execute it after
-      it's reached quorum.
+      Your workstream won't start streaming funds until the proposed transaction
+      reaches quorum and is executed by your Gnosis Safe. Head over to your safe
+      now, sign the transaction, and execute it after it's reached quorum. <br
+      /> You can re-propose the transaction anytime by clicking on "Set up stream"
+      again.
     </p>
   </div>
   <div slot="step-actions">

--- a/src/lib/components/WorkstreamCard.svelte
+++ b/src/lib/components/WorkstreamCard.svelte
@@ -78,7 +78,7 @@
             total={ws.total}
           />
         {/if}
-        {#if ws.state === WorkstreamState.ACTIVE && onChainDataReady}
+        {#if ws.state === WorkstreamState.ACTIVE && enrichedWorkstream?.onChainData?.streamSetUp && onChainDataReady}
           <div class="remaining" transition:fade|local>
             • <span class="amount"
               >{currencyFormat(estimate.remainingBalance)} DAI

--- a/src/lib/components/WorkstreamDetail/ActiveStream.svelte
+++ b/src/lib/components/WorkstreamDetail/ActiveStream.svelte
@@ -132,7 +132,7 @@
               icon={PauseIcon}>Unpause</Button
             >
           {/if}
-          {#if workstream.state === WorkstreamState.PENDING}
+          {#if workstream.state === WorkstreamState.ACTIVE && !enrichedWorkstream?.onChainData?.streamSetUp}
             <Button
               on:click={() =>
                 modal.show(StepperModal, undefined, {

--- a/src/lib/components/WorkstreamDetail/index.svelte
+++ b/src/lib/components/WorkstreamDetail/index.svelte
@@ -25,7 +25,7 @@
       <span class="label">on {dateFormat(workstream.created_at)}</span>
     </div>
     <div class="cards">
-      {#if workstream.state === WorkstreamState.ACTIVE || workstream.state === WorkstreamState.PENDING}
+      {#if workstream.state === WorkstreamState.ACTIVE}
         <ActiveStream {workstream} />
       {:else}
         <ApplyRow {workstream} />

--- a/src/lib/components/WorkstreamStateBadge.svelte
+++ b/src/lib/components/WorkstreamStateBadge.svelte
@@ -17,14 +17,14 @@
     ACTIVE,
     /** Stream needds to be created by the creator */
     PENDING_SETUP,
-    /** Transaction to set up Drip is pending in Gnosis Safe */
-    PENDING_CONFIRMATION,
     /** Stream is active, but no more balance is remaining in Drips account */
     OUT_OF_FUNDS,
     /** Stream was set up, but then paused by removing drip receiver */
     PAUSED,
     /** Stream marked as closed via API */
-    CLOSED
+    CLOSED,
+    /** Stream state cannot be determined because the user isn't logged in.*/
+    UNKNOWN
   }
 
   let visualState: VisualState;
@@ -32,10 +32,10 @@
   $: visualStateLabel = {
     [VisualState.ACTIVE]: 'Active',
     [VisualState.PENDING_SETUP]: 'Pending setup',
-    [VisualState.PENDING_CONFIRMATION]: 'Pending confirmation',
     [VisualState.OUT_OF_FUNDS]: 'Out of funds',
     [VisualState.PAUSED]: 'Paused',
-    [VisualState.CLOSED]: 'Closed'
+    [VisualState.CLOSED]: 'Closed',
+    [VisualState.UNKNOWN]: 'Log in to see status'
   }[visualState];
 
   $: visualStateColor = {
@@ -43,8 +43,8 @@
     [VisualState.PENDING_SETUP]: '--color-caution',
     [VisualState.OUT_OF_FUNDS]: '--color-negative',
     [VisualState.PAUSED]: '--color-caution',
-    [VisualState.PENDING_CONFIRMATION]: '--color-caution',
-    [VisualState.CLOSED]: '--color-foreground'
+    [VisualState.CLOSED]: '--color-foreground',
+    [VisualState.UNKNOWN]: '--color-foreground'
   }[visualState];
 
   $: {
@@ -54,22 +54,20 @@
           enrichedWorkstream?.onChainData &&
           !enrichedWorkstream.onChainData.streamSetUp
         ) {
-          visualState = VisualState.PENDING_CONFIRMATION;
+          visualState = VisualState.PENDING_SETUP;
         } else if (estimate && !estimate.currentlyStreaming) {
           visualState = estimate.paused
             ? VisualState.PAUSED
             : VisualState.OUT_OF_FUNDS;
-        } else {
+        } else if (enrichedWorkstream?.onChainData?.streamSetUp) {
           visualState = VisualState.ACTIVE;
+        } else if (enrichedWorkstream) {
+          visualState = VisualState.UNKNOWN;
         }
         break;
       }
       case WorkstreamState.CLOSED: {
         visualState = VisualState.CLOSED;
-        break;
-      }
-      case WorkstreamState.PENDING: {
-        visualState = VisualState.PENDING_SETUP;
         break;
       }
     }

--- a/src/lib/stores/drips/index.ts
+++ b/src/lib/stores/drips/index.ts
@@ -4,7 +4,6 @@ import {
   type ethers,
   type ContractTransaction
 } from 'ethers';
-import { randomHex } from 'web3-utils';
 import { get, writable } from 'svelte/store';
 
 import { Currency, type Money } from '../workstreams/types';
@@ -110,13 +109,6 @@ export default (() => {
       currentCycleStart.getTime() + Number(cycleSecs * BigInt(1000))
     );
 
-    console.log({
-      cycleSecs,
-      currentCycleSecs,
-      currentCycleStart,
-      nextCycleStart
-    });
-
     state.update((v) => ({
       ...v,
       cycle: {
@@ -215,10 +207,6 @@ export default (() => {
     );
 
     return daiContract.balanceOf(await provider.getSigner().getAddress());
-  }
-
-  function getRandomAccountId() {
-    return BigNumber.from(randomHex(32)).toBigInt();
   }
 
   async function createDrip(
@@ -366,7 +354,6 @@ export default (() => {
     subscribe: state.subscribe,
     connect,
     disconnect,
-    getRandomAccountId,
     pauseUnpause,
     createDrip,
     topUp,

--- a/src/lib/stores/wallet/wallet.ts
+++ b/src/lib/stores/wallet/wallet.ts
@@ -330,7 +330,6 @@ export const walletStore = (() => {
   function _attachListeners(
     to: WalletConnectProvider | MetaMaskInpageProvider
   ) {
-    console.log('attaching listeners', to);
     to.on('accountsChanged', (newAccounts: string[]) => {
       const accounts = prepareAccounts(newAccounts);
 
@@ -348,7 +347,6 @@ export const walletStore = (() => {
     });
 
     to.on('chainChanged', () => {
-      console.log('chainChanged');
       location.reload();
     });
   }

--- a/src/lib/stores/wallet/wallet.ts
+++ b/src/lib/stores/wallet/wallet.ts
@@ -120,6 +120,8 @@ export const walletStore = (() => {
     const network = await provider?.getNetwork();
     const login = accounts?.length > 0 && _restoreAuth(accounts);
 
+    if (detectedWindowProvider) _attachListeners(detectedWindowProvider);
+
     state.set({
       metamaskInstalled: Boolean(detectedWindowProvider),
       accounts: (accounts && prepareAccounts(accounts)) || [],
@@ -328,6 +330,7 @@ export const walletStore = (() => {
   function _attachListeners(
     to: WalletConnectProvider | MetaMaskInpageProvider
   ) {
+    console.log('attaching listeners', to);
     to.on('accountsChanged', (newAccounts: string[]) => {
       const accounts = prepareAccounts(newAccounts);
 
@@ -345,6 +348,7 @@ export const walletStore = (() => {
     });
 
     to.on('chainChanged', () => {
+      console.log('chainChanged');
       location.reload();
     });
   }

--- a/src/lib/stores/workstreams/methods/fetchRelevantWorkstreams.ts
+++ b/src/lib/stores/workstreams/methods/fetchRelevantWorkstreams.ts
@@ -1,13 +1,18 @@
 import { workstreamsStore } from '..';
 
-export default async function (address: string) {
+export default async function (address: string, chainId: number) {
   return await Promise.all([
     await workstreamsStore.getWorkstreams({
-      assignedTo: address
+      assignedTo: address,
+      chainId: String(chainId)
     }),
     await workstreamsStore.getWorkstreams({
-      createdBy: address
+      createdBy: address,
+      chainId: String(chainId)
     }),
-    await workstreamsStore.getWorkstreams({ applied: 'true' })
+    await workstreamsStore.getWorkstreams({
+      applied: 'true',
+      chainId: String(chainId)
+    })
   ]);
 }

--- a/src/lib/stores/workstreams/types.ts
+++ b/src/lib/stores/workstreams/types.ts
@@ -8,9 +8,7 @@ export interface Timestamp {
 export enum WorkstreamState {
   RFA = 'rfa', // Request for Applications. Initial state of Workstream
   ACTIVE = 'active',
-  CLOSED = 'closed',
-  CANCELLED = 'cancelled',
-  PENDING = 'pending'
+  CLOSED = 'closed'
 }
 
 export enum Currency {
@@ -30,7 +28,7 @@ export interface Workstream {
   total: Money;
   title: string;
   desc: string;
-  dripsData?: {
+  dripsData: {
     accountId: bigint;
     chainId: number;
   };
@@ -53,14 +51,16 @@ export type WorkstreamInput =
       title: string;
       desc: string;
       durationDays: number;
+      chainId: number;
     }
   | {
       ratePerSecond: MoneyInput;
       title: string;
       desc: string;
       durationDays: number;
-      state: WorkstreamState.PENDING;
+      state: WorkstreamState.ACTIVE;
       assignTo: string;
+      chainId: number;
     };
 
 export enum ApplicationState {

--- a/src/routes/dashboard/index.svelte
+++ b/src/routes/dashboard/index.svelte
@@ -71,7 +71,8 @@
       title: 'Workstreams pending payment setup',
       workstreams: filterObject(workstreams, (ws) => {
         return (
-          ws.data.state === WorkstreamState.PENDING &&
+          ws.data.state === WorkstreamState.ACTIVE &&
+          !ws.onChainData.streamSetUp &&
           (ws.data.creator === address ||
             ws.data.acceptedApplication === address)
         );
@@ -101,7 +102,7 @@
       workstreams: filterObject(workstreams, (ws) => {
         return (
           ws.data.state === WorkstreamState.ACTIVE &&
-          ws.onChainData &&
+          ws.onChainData?.streamSetUp &&
           ws.data.acceptedApplication === address
         );
       })
@@ -117,7 +118,7 @@
       workstreams: filterObject(workstreams, (ws) => {
         return (
           ws.data.state === WorkstreamState.ACTIVE &&
-          ws.onChainData &&
+          ws.onChainData?.streamSetUp &&
           ws.data.creator === address
         );
       })

--- a/src/routes/history/index.svelte
+++ b/src/routes/history/index.svelte
@@ -16,7 +16,7 @@
   const { estimates } = workstreamsStore;
 
   $: relevantStreams = Object.values($workstreamsStore.workstreams).filter(
-    (ws) => ws.onChainData
+    (ws) => ws.relevant
   );
 
   let loading = true;


### PR DESCRIPTION
Depends on https://github.com/radicle-dev/workstreams-api-node/pull/28 and DB migration

This PR removes the `pending` state from Workstreams, and instead infers whether a workstream should be displayed as "Active" or "Pending setup" using on-chain data. As part of that, the workstream activation call has been removed. Additionally, drips account IDs are no longer generated client-side — instead, the server-generated ID on workstream creation is used when calling `setDrips`.

Resolves #166 