### PR TITLE
Enhance linter config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -20,5 +20,9 @@ module.exports = {
     browser: true,
     es2017: true,
     node: true
+  },
+  rules: {
+    'no-console': 'error',
+    '@typescript-eslint/no-unused-vars': 'error',
   }
 };

--- a/src/lib/stores/drips/index.ts
+++ b/src/lib/stores/drips/index.ts
@@ -110,13 +110,6 @@ export default (() => {
       currentCycleStart.getTime() + Number(cycleSecs * BigInt(1000))
     );
 
-    console.log({
-      cycleSecs,
-      currentCycleSecs,
-      currentCycleStart,
-      nextCycleStart
-    });
-
     state.update((v) => ({
       ...v,
       cycle: {


### PR DESCRIPTION
Enables 'no-comment' and 'no-unused-vars' as errors. Will automatically be checked on commit using `lint-staged`.