### PR TITLE
feat: Estimate earnings in current cycle

### DIFF
--- a/src/lib/components/BalanceButton.svelte
+++ b/src/lib/components/BalanceButton.svelte
@@ -77,29 +77,27 @@
     <div class="hover-pad" />
     <div in:fly={{ y: 10 }} out:fly={{ y: 10 }} class="dropdown">
       <div class="amounts">
-        <div class="row">
-          <div class="title-value withdrawable">
-            <p class="typo-text title">Withdrawable now</p>
-            <h2 class="value">
-              {#if withdrawable}
-                {padFloatString(withdrawable)} DAI
-              {:else}
-                <LoadingDots />
-              {/if}
-            </h2>
-          </div>
-          <div class="title-value balance">
-            <p class="typo-text title">
-              Withdrawable from {formattedCycleEnd?.date || '...'}
-            </p>
-            <h2 class="value">
-              {#if currentCycleBalanceEstimate}
-                +{padFloatString(currentCycleBalanceEstimate)} DAI
-              {:else}
-                <LoadingDots />
-              {/if}
-            </h2>
-          </div>
+        <div class="title-value withdrawable">
+          <p class="typo-text title">Withdrawable now</p>
+          <h2 class="value">
+            {#if withdrawable}
+              {padFloatString(withdrawable)} DAI
+            {:else}
+              <LoadingDots />
+            {/if}
+          </h2>
+        </div>
+        <div class="title-value balance">
+          <p class="typo-text title">
+            Withdrawable {formattedCycleEnd?.date || '...'}
+          </p>
+          <h2 class="value">
+            {#if currentCycleBalanceEstimate}
+              +{padFloatString(currentCycleBalanceEstimate)} DAI
+            {:else}
+              <LoadingDots />
+            {/if}
+          </h2>
         </div>
       </div>
       <div class="info">
@@ -159,7 +157,7 @@
     position: absolute;
     top: 3rem;
     right: 0;
-    width: 26rem;
+    width: 28rem;
     border-radius: 0.5rem;
     display: flex;
     gap: 1rem;
@@ -169,14 +167,8 @@
   }
 
   .amounts {
-    flex-direction: column;
     display: flex;
-    gap: 1rem;
-  }
-
-  .amounts > .row {
-    display: flex;
-    gap: 2rem;
+    gap: 0.5rem;
   }
 
   .title {

--- a/src/lib/components/WithdrawSteps/Intro.svelte
+++ b/src/lib/components/WithdrawSteps/Intro.svelte
@@ -49,7 +49,7 @@
     </p>
     <p class="typo-text-small">
       Please note that while you're earning in real-time, your withdrawable
-      amount updates once a week.
+      amount updates once every thirty days.
       {#if $drips.cycle?.end}
         It will update next on {Intl.DateTimeFormat('en-US', {
           month: 'short',

--- a/src/lib/stores/drips/utils/streamedBetween.ts
+++ b/src/lib/stores/drips/utils/streamedBetween.ts
@@ -79,7 +79,11 @@ export function amountsEarnedAndSpentBetween(
   const amounts = streamedBetween(streams, timeWindow);
 
   return {
-    earned: amounts.filter((a) => a.workstream.direction === 'incoming'),
-    spent: amounts.filter((a) => a.workstream.direction === 'outgoing')
+    earned: amounts.filter(
+      (a) => a.workstream.direction === 'incoming' && a.amount.wei > 0
+    ),
+    spent: amounts.filter(
+      (a) => a.workstream.direction === 'outgoing' && a.amount.wei > 0
+    )
   };
 }

--- a/src/lib/stores/drips/utils/streamedBetween.ts
+++ b/src/lib/stores/drips/utils/streamedBetween.ts
@@ -7,8 +7,8 @@ interface TimeWindow {
 }
 
 /**
- * Calculates the exact amounts earned and spent within a given time window and
- * list of workstreams to consider.
+ * Calculates the exact amounts streamed and remaining for streams related
+ * to a given array of EnrichedWorkstream objects.
  */
 export function streamedBetween(
   streams: EnrichedWorkstream[],
@@ -72,6 +72,10 @@ export function streamedBetween(
   return amountsStreamed;
 }
 
+/**
+ * Breaks down the amounts earned and spent by the currently logged-in
+ * user for a given array of EnrichedWorkstream objects.
+ */
 export function amountsEarnedAndSpentBetween(
   streams: EnrichedWorkstream[],
   timeWindow: TimeWindow = { from: new Date(0), to: new Date() }

--- a/src/lib/stores/drips/utils/streamedBetween.ts
+++ b/src/lib/stores/drips/utils/streamedBetween.ts
@@ -1,21 +1,30 @@
 import type { EnrichedWorkstream } from '$lib/stores/workstreams';
 import { Currency, type Money } from '$lib/stores/workstreams/types';
 
+interface TimeWindow {
+  from: Date;
+  to: Date;
+}
+
 /**
  * Calculates the exact amounts earned and spent within a given time window and
  * list of workstreams to consider.
  */
-export default function streamedBetween(
-  timeWindow: { from: Date; to: Date },
-  streams: EnrichedWorkstream[]
+export function streamedBetween(
+  streams: EnrichedWorkstream[],
+  timeWindow: TimeWindow = { from: new Date(0), to: new Date() }
 ) {
-  const amountsStreamed: { workstream: EnrichedWorkstream; amount: Money }[] =
-    [];
+  const amountsStreamed: {
+    workstream: EnrichedWorkstream;
+    amount: Money;
+    remaining: Money;
+  }[] = [];
 
   for (const stream of streams) {
     const events = stream.onChainData.dripsUpdatedEvents;
 
     let amountStreamed = BigInt(0);
+    let amountRemaining = BigInt(0);
 
     events.forEach((dew, index) => {
       const nextDew = events[index + 1];
@@ -24,11 +33,11 @@ export default function streamedBetween(
         nextDew?.fromBlock.timestamp || new Date().getTime() / 1000;
       const amtPerSec =
         dew.event.args.receivers[0]?.amtPerSec.toBigInt() || BigInt(0);
+      const balance = dew.event.args.balance.toBigInt();
 
       if (amtPerSec === BigInt(0)) return;
 
-      const toppedUpUntil =
-        validSince + Number(dew.event.args.balance.toBigInt() / amtPerSec);
+      const toppedUpUntil = validSince + Number(balance / amtPerSec);
 
       const relevantWindow = {
         from: Math.max(validSince, timeWindow.from.getTime() / 1000),
@@ -38,24 +47,39 @@ export default function streamedBetween(
       const secondsInWindow = Math.floor(
         Math.max(relevantWindow.to - relevantWindow.from, 0)
       );
-      amountStreamed = amountStreamed + BigInt(secondsInWindow) * amtPerSec;
+
+      const streamedDuringCurrentEvent = BigInt(secondsInWindow) * amtPerSec;
+      amountStreamed = amountStreamed + streamedDuringCurrentEvent;
+
+      if (index === events.length - 1) {
+        amountRemaining = balance - streamedDuringCurrentEvent;
+      }
     });
 
-    if (amountStreamed) {
-      amountsStreamed.push({
-        workstream: stream,
-        amount: {
-          currency: Currency.DAI,
-          wei: amountStreamed
-        }
-      });
-    }
+    amountsStreamed.push({
+      workstream: stream,
+      amount: {
+        currency: Currency.DAI,
+        wei: amountStreamed
+      },
+      remaining: {
+        currency: Currency.DAI,
+        wei: amountRemaining
+      }
+    });
   }
 
+  return amountsStreamed;
+}
+
+export function amountsEarnedAndSpentBetween(
+  streams: EnrichedWorkstream[],
+  timeWindow: TimeWindow = { from: new Date(0), to: new Date() }
+) {
+  const amounts = streamedBetween(streams, timeWindow);
+
   return {
-    earned: amountsStreamed.filter(
-      (a) => a.workstream.direction === 'incoming'
-    ),
-    spent: amountsStreamed.filter((a) => a.workstream.direction === 'outgoing')
+    earned: amounts.filter((a) => a.workstream.direction === 'incoming'),
+    spent: amounts.filter((a) => a.workstream.direction === 'outgoing')
   };
 }

--- a/src/routes/history/historyItemAggregators/monthStartInbetween.ts
+++ b/src/routes/history/historyItemAggregators/monthStartInbetween.ts
@@ -1,4 +1,4 @@
-import streamedBetween from '$lib/stores/drips/utils/streamedBetween';
+import { amountsEarnedAndSpentBetween } from '$lib/stores/drips/utils/streamedBetween';
 import { Currency } from '$lib/stores/workstreams/types';
 import type { HistoryAggregator } from '../history';
 import { HistoryItemType } from '../types';
@@ -29,7 +29,10 @@ export const monthStartInbetween: HistoryAggregator = (queue, streams) => {
         to: monthEnd
       };
 
-      const { earned, spent } = streamedBetween(window, streams);
+      let { earned, spent } = amountsEarnedAndSpentBetween(streams, window);
+
+      earned = earned.filter((e) => e.amount.wei > 0);
+      spent = spent.filter((s) => s.amount.wei > 0);
 
       newItems.push({
         type: HistoryItemType.MonthStartInbetween,

--- a/src/routes/history/historyItemAggregators/monthStartInbetween.ts
+++ b/src/routes/history/historyItemAggregators/monthStartInbetween.ts
@@ -29,10 +29,7 @@ export const monthStartInbetween: HistoryAggregator = (queue, streams) => {
         to: monthEnd
       };
 
-      let { earned, spent } = amountsEarnedAndSpentBetween(streams, window);
-
-      earned = earned.filter((e) => e.amount.wei > 0);
-      spent = spent.filter((s) => s.amount.wei > 0);
+      const { earned, spent } = amountsEarnedAndSpentBetween(streams, window);
 
       newItems.push({
         type: HistoryItemType.MonthStartInbetween,

--- a/src/routes/history/historyItemAggregators/streamedInbetween.ts
+++ b/src/routes/history/historyItemAggregators/streamedInbetween.ts
@@ -1,4 +1,4 @@
-import streamedBetween from '$lib/stores/drips/utils/streamedBetween';
+import { amountsEarnedAndSpentBetween } from '$lib/stores/drips/utils/streamedBetween';
 import { Currency } from '$lib/stores/workstreams/types';
 import type { HistoryAggregator } from '../history';
 import { HistoryItemType } from '../types';
@@ -21,7 +21,10 @@ export const streamedInbetween: HistoryAggregator = (queue, streams) => {
       from: prevTimestamp
     };
 
-    const { earned, spent } = streamedBetween(window, streams);
+    let { earned, spent } = amountsEarnedAndSpentBetween(streams, window);
+
+    earned = earned.filter((e) => e.amount.wei > 0);
+    spent = spent.filter((s) => s.amount.wei > 0);
 
     if (earned.length > 0 || spent.length > 0) {
       newItems.push({

--- a/src/routes/history/historyItemAggregators/streamedInbetween.ts
+++ b/src/routes/history/historyItemAggregators/streamedInbetween.ts
@@ -21,10 +21,7 @@ export const streamedInbetween: HistoryAggregator = (queue, streams) => {
       from: prevTimestamp
     };
 
-    let { earned, spent } = amountsEarnedAndSpentBetween(streams, window);
-
-    earned = earned.filter((e) => e.amount.wei > 0);
-    spent = spent.filter((s) => s.amount.wei > 0);
+    const { earned, spent } = amountsEarnedAndSpentBetween(streams, window);
 
     if (earned.length > 0 || spent.length > 0) {
       newItems.push({

--- a/src/routes/history/historyItemAggregators/today.ts
+++ b/src/routes/history/historyItemAggregators/today.ts
@@ -1,4 +1,4 @@
-import streamedBetween from '$lib/stores/drips/utils/streamedBetween';
+import { amountsEarnedAndSpentBetween } from '$lib/stores/drips/utils/streamedBetween';
 import { Currency } from '$lib/stores/workstreams/types';
 import type { HistoryAggregator } from '../history';
 import { HistoryItemType } from '../types';
@@ -18,7 +18,10 @@ export const today: HistoryAggregator = (queue, streams) => {
     )
   };
 
-  const { earned, spent } = streamedBetween(window, streams);
+  let { earned, spent } = amountsEarnedAndSpentBetween(streams, window);
+
+  earned = earned.filter((e) => e.amount.wei > 0);
+  spent = spent.filter((s) => s.amount.wei > 0);
 
   return [
     {

--- a/src/routes/history/historyItemAggregators/today.ts
+++ b/src/routes/history/historyItemAggregators/today.ts
@@ -18,10 +18,7 @@ export const today: HistoryAggregator = (queue, streams) => {
     )
   };
 
-  let { earned, spent } = amountsEarnedAndSpentBetween(streams, window);
-
-  earned = earned.filter((e) => e.amount.wei > 0);
-  spent = spent.filter((s) => s.amount.wei > 0);
+  const { earned, spent } = amountsEarnedAndSpentBetween(streams, window);
 
   return [
     {

--- a/src/routes/history/index.svelte
+++ b/src/routes/history/index.svelte
@@ -5,7 +5,6 @@
   import { workstreamsStore } from '$lib/stores/workstreams';
   import HistoryItem from '$lib/components/History/HistoryItem.svelte';
   import { currencyFormat } from '$lib/utils/format';
-  import drips from '$lib/stores/drips';
   import history from './history';
   import * as aggregators from './historyItemAggregators';
   import Spinner from 'radicle-design-system/Spinner.svelte';
@@ -65,15 +64,8 @@
         <div class="key-value">
           <h4>Total earned</h4>
           <p class="amount typo-text-mono-bold">
-            +{($estimates.totalBalance &&
+            {($estimates.totalBalance &&
               currencyFormat($estimates.totalBalance.wei)) ||
-              '…'} DAI
-          </p>
-        </div>
-        <div class="key-value">
-          <h4>Withdrawable now</h4>
-          <p class="typo-text-mono-bold">
-            {($drips.collectable && currencyFormat($drips.collectable.wei)) ||
               '…'} DAI
           </p>
         </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1018218/183865208-dde94c42-d6bb-421a-ac25-d5572783ad63.png)

Displays the earnings in the current Drips cycle up in the balance dropdown, and replaces the total earned value in the button label with the more practical value of `currently withdrawable + earned in current cycle`.

Behind the scenes, I also consolidated some of the logic for balance estimation.