### PR TITLE
fix: no startstop items in history

### DIFF
--- a/src/routes/history/historyItemAggregators/streamStartStop.ts
+++ b/src/routes/history/historyItemAggregators/streamStartStop.ts
@@ -30,7 +30,8 @@ export const streamStartStop: HistoryAggregator = (_, streams) => {
 
         const streamingUntil =
           timestamp.getTime() / 1000 + Number(balance.wei / amtPerSec.wei);
-        const nextTimestamp = (timestamp || new Date()).getTime() / 1000;
+        const nextTimestamp =
+          (nextEvent?.timestamp || new Date()).getTime() / 1000;
 
         if (streamingUntil > nextTimestamp) {
           return acc;


### PR DESCRIPTION
In some situations, the `stream ran out of funds` and `stream topped up` events were missing in the history, this fixes it.